### PR TITLE
Fix update_path

### DIFF
--- a/invoke/loader.py
+++ b/invoke/loader.py
@@ -27,8 +27,7 @@ class Loader(object):
         # If we want to auto-strip .py:
         # os.path.splitext(os.path.basename(name))[0]
         # TODO: copy over rest of path munging from fabric.main
-        if parent not in our_path:
-            our_path.insert(0, parent)
+        our_path.insert(0, parent)
         return our_path
 
     def find_collection(self, name):


### PR DESCRIPTION
`update_path` should not check if the parent path is already in
`sys.path`. It should always put it at the start so that it's picked up
first.

Fixes https://github.com/pyinvoke/invoke/issues/91
