### PR TITLE
Fix distutils setup, trove classifiers indentation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except ImportError:
     from distutils.core import setup
 
     def find_packages(*args, **kwargs):
-        return ['invoke']
+        return ['invoke', 'invoke.parser']
 
 # Version info -- read without importing
 _locals = {}


### PR DESCRIPTION
distutils doesn't have a `find_packages` so this would break if it was ever used.
