### PR TITLE
Prints task docstring when calling --list

### DIFF
--- a/invoke/cli.py
+++ b/invoke/cli.py
@@ -219,7 +219,14 @@ def parse(argv, collection=None):
             out = primary
             if aliases:
                 out += " (%s)" % ', '.join(aliases)
-            print("  %s" % out)
+
+            doc = collection[primary].__doc__
+            if doc:
+                doc = doc.strip()
+            else:
+                doc = ""
+
+            print("  {0}\t- {1}".format(out, doc))
         print("")
         sys.exit(0)
 


### PR DESCRIPTION
This makes it easier to understand what tasks do what, and replicates the behavior of rake and paver.
