### PR TITLE
print return value of main-tasks

### DIFF
--- a/invoke/cli.py
+++ b/invoke/cli.py
@@ -277,4 +277,5 @@ def main():
     # Parse command line
     debug("Base argv from sys: %r" % (sys.argv[1:],))
     for result in dispatch(sys.argv):
-        print(result)
+        if result is not None:
+            print(result)


### PR DESCRIPTION
This is a very minor change but it makes it possible to use the result of a task both when calling it from another task

``` python
@task
def get_version():
    return 123

@task
def foo():
    version = get_version()
```

and from the shell

``` bash
$> inv get_version
123
```

If there are no objections to this, I could add some tests for it.
