### PR TITLE
run() variable expansion

### DIFF
--- a/invoke/context.py
+++ b/invoke/context.py
@@ -1,6 +1,11 @@
 from copy import deepcopy
+from string import Template
 
 from .runner import run
+
+
+class CmdTemplate(Template):
+    idpattern = '[a-z0-9_\-\.]+'
 
 
 class Context(object):
@@ -71,6 +76,11 @@ class Context(object):
         """
         options = dict(self.config['run'])
         options.update(kwargs)
+        cmd_config = options.pop('config', {})
+        if options.pop('expand', False):
+            config = self.config['general']
+            args = [CmdTemplate(arg).substitute(config, **cmd_config)
+                    for arg in args]
         return run(*args, **options)
 
     def __getitem__(self, *args, **kwargs):

--- a/tests/context.py
+++ b/tests/context.py
@@ -31,6 +31,48 @@ class Context_(Spec):
         def echo(self):
             self._honors('echo', True)
 
+    class run_and_expand:
+
+        def vars_from_context_config(self):
+            with patch('invoke.context.run') as run:
+                Context(config={'foo': 'bar'}).run('echo $foo', expand=True)
+                run.assert_called_with('echo bar')
+
+        def vars_from_run_config(self):
+            with patch('invoke.context.run') as run:
+                Context().run('echo $foo', expand=True, config={'foo': 'xyz'})
+                run.assert_called_with('echo xyz')
+
+        def vars_from_run_config_overrides_context_config(self):
+            with patch('invoke.context.run') as run:
+                Context(config={'foo': 'bar'}).run(
+                    'echo $foo', expand=True, config={'foo': 'xyz'})
+                run.assert_called_with('echo xyz')
+
+        def expand_set_on_context(self):
+            with patch('invoke.context.run') as run:
+                Context(config={'foo': 'bar'}, run={'expand': True}).run(
+                    'echo $foo')
+                run.assert_called_with('echo bar')
+
+        def var_with_dot(self):
+            with patch('invoke.context.run') as run:
+                Context(config={'foo.x': 'bar'}).run(
+                    'echo $foo.x', expand=True)
+                run.assert_called_with('echo bar')
+
+        def var_with_dash(self):
+            with patch('invoke.context.run') as run:
+                Context(config={'foo-x': 'bar'}).run(
+                    'echo $foo-x', expand=True)
+                run.assert_called_with('echo bar')
+
+        def var_with_braces(self):
+            with patch('invoke.context.run') as run:
+                Context(config={'foo': 'bar', 'foox': 'xyz'}).run(
+                    'echo ${foo}x', expand=True)
+                run.assert_called_with('echo barx')
+
     class clone:
         def returns_copy_of_self(self):
             skip()


### PR DESCRIPTION
Expand config vars in command when `expand` option is `True`:

``` python
ns.configure({'username': 'john'})

context.run('echo $username', expand=True)
context.run('echo $foo', expand=True, config={'foo': 'bar'})
```

runs `echo john` and 'echo bar'.

With this writing invoke tasks feels a lot smoother to me - almost like a python shell.

What are your thoughts on this?
