### PR TITLE
Flag values should shouldn't be parsed as flags

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 # Docs
 Sphinx>=1.1.2
-releases>=0.6.1
+-e git+https://github.com/bitprophet/releases#egg=releases
 # Testing (explicit dependencies to get around a Travis/pip issue)
 # N.B. Nose 1.3.1+ has a bizarro display bug re: exception printing
 nose==1.3.0

--- a/invoke/parser/parser.py
+++ b/invoke/parser/parser.py
@@ -162,16 +162,16 @@ class ParseMachine(StateMachine):
             debug("Top-of-handle() see_unknown(%r)" % token)
             self.see_unknown(token)
             return
+        # Value for current flag
+        if self.waiting_for_flag_value:
+            self.see_value(token)
         # Flag
-        if self.context and token in self.context.flags:
+        elif self.context and token in self.context.flags:
             debug("Saw flag %r" % token)
             self.switch_to_flag(token)
         elif self.context and token in self.context.inverse_flags:
             debug("Saw inverse flag %r" % token)
             self.switch_to_flag(token, inverse=True)
-        # Value for current flag
-        elif self.waiting_for_flag_value:
-            self.see_value(token)
         # Positional args (must come above context-name check in case we still
         # need a posarg and the user legitimately wants to give it a value that
         # just happens to be a valid context name.)

--- a/tests/parser/parser.py
+++ b/tests/parser/parser.py
@@ -164,6 +164,15 @@ class Parser_(Spec):
             eq_(a.value, None)
             eq_(a2.value, 'val')
 
+        def flag_values_not_parsed_as_flags(self):
+            a = Argument('foo', default=False, optional=True)
+            b = Argument('bar', default='')
+            c = Context(name='mytask', args=(a, b))
+            p = Parser(contexts=(c,))
+            r = p.parse_argv(['mytask', '--bar=--foo'])
+            assert not r[0].args['foo'].value
+            eq_(r[0].args['bar'].value, '--foo')
+
         class parsing_errors:
             def setup(self):
                 self.p = Parser([Context(name='foo', args=[Argument('bar')])])


### PR DESCRIPTION
- String arguments that look like flags should no longer be parsed. Fixes #154. 
- Upgrade `releases` to get builds going again.
