### PR TITLE
Smart collection loading

### DIFF
--- a/invoke/loader.py
+++ b/invoke/loader.py
@@ -1,4 +1,5 @@
 import os
+import pkgutil
 import sys
 import imp
 
@@ -89,7 +90,23 @@ class FilesystemLoader(Loader):
         # we turn it into a more obvious exception class.
         try:
             tup = imp.find_module(name, parents)
-            debug("Found module: {0!r}".format(tup[1]))
+            debug("FSL: Found module: {0!r}".format(tup[1]))
             return tup
         except ImportError:
             raise CollectionNotFound(name=name, start=start)
+
+
+class PackageLoader(Loader):
+    """
+    Loads Python files from the package (e.g. ``mypackage.inner.tasks``.)
+    """
+
+    def load(self, name=DEFAULT_COLLECTION_NAME):
+        debug("PackageLoader find starting")
+        loader = pkgutil.get_loader(name)
+        if not loader:
+            raise CollectionNotFound(name=name, start="")
+        else:
+            debug("PL: Found module: {0!r}".format(name))
+            res = loader.load_module(name)
+            return Collection.from_module(res)

--- a/tests/loader.py
+++ b/tests/loader.py
@@ -4,7 +4,7 @@ import sys
 
 from spec import Spec, skip, eq_, raises
 
-from invoke.loader import Loader, FilesystemLoader as FSLoader
+from invoke.loader import Loader, FilesystemLoader as FSLoader, PackageLoader
 from invoke.collection import Collection
 from invoke.exceptions import CollectionNotFound
 
@@ -75,3 +75,22 @@ class FilesystemLoader_(Spec):
         "defaults to 'tasks' collection"
         result = FSLoader(start=support + '/implicit/').load()
         eq_(type(result), Collection)
+
+
+class PackageLoader_(Spec):
+    def setup(self):
+        self.l = PackageLoader()
+
+    def returns_collection_object_if_name_found(self):
+        # This module is definitely installed
+        result = self.l.load('invoke.parser.context')
+        eq_(type(result), Collection)
+
+    @raises(CollectionNotFound)
+    def raises_CollectionNotFound_if_not_found(self):
+        self.l.load('nope')
+
+    @raises(ImportError)
+    def raises_ImportError_if_found_collection_cannot_be_imported(self):
+        # Instead of masking with a CollectionNotFound
+        self.l.load('oops')


### PR DESCRIPTION
If collection name contains dot and doesn’t end with `.py` - treat that as fully qualified name and try to load package using `pkgutil`

Fixes #138 
