### PR TITLE
Allow subcollections to be defaults of parent collections

### DIFF
--- a/invoke/collection.py
+++ b/invoke/collection.py
@@ -202,7 +202,7 @@ class Collection(object):
                 raise ValueError(msg % (name, self.default))
             self.default = name
 
-    def add_collection(self, coll, name=None):
+    def add_collection(self, coll, name=None, default=None):
         """
         Add `.Collection` ``coll`` as a sub-collection of this one.
 
@@ -211,6 +211,8 @@ class Collection(object):
         :param str name:
             The name to attach the collection as. Defaults to the collection's
             own internal name.
+
+        :param default: Whether this sub-collection should be the default.
         """
         # Handle module-as-collection
         if isinstance(coll, types.ModuleType):
@@ -224,6 +226,11 @@ class Collection(object):
             raise ValueError("Name conflict: this collection has a task named %r already" % name)
         # Insert
         self.collections[name] = coll
+        if default:
+            if self.default:
+                msg = "'%s' cannot be the default because '%s' already is!"
+                raise ValueError(msg % (name, self.default))
+            self.default = coll
 
     def split_path(self, path):
         """
@@ -275,10 +282,12 @@ class Collection(object):
         ours = self.configuration()
         # Default task for this collection itself
         if not name:
-            if self.default:
-                return self[self.default], ours
-            else:
+            if not self.default:
                 raise ValueError("This collection has no default task.")
+            if isinstance(self.default, Collection):
+                return self._task_with_merged_config(self.default.name, '', ours)
+            else:
+                return self[self.default], ours
         # Non-default tasks within subcollections -> recurse (sorta)
         if '.' in name:
             coll, rest = self.split_path(name)

--- a/tests/collection.py
+++ b/tests/collection.py
@@ -255,6 +255,11 @@ class Collection_(Spec):
             self.c.add_collection(load('integration'))
             assert 'integration' in self.c.collections
 
+        def allows_specifying_defaultness(self):
+            collection = Collection('foo')
+            self.c.add_collection(collection, default=True)
+            eq_(self.c.default, collection)
+
         @raises(ValueError)
         def raises_ValueError_if_collection_without_name(self):
             # Aka non-root collections must either have an explicit name given
@@ -268,6 +273,13 @@ class Collection_(Spec):
         def raises_ValueError_if_collection_named_same_as_task(self):
             self.c.add_task(_mytask, 'sub')
             self.c.add_collection(Collection('sub'))
+
+        @raises(ValueError)
+        def raises_ValueError_on_multiple_defaults(self):
+            t1 = Task(_func, default=True)
+            self.c.add_task(t1, 'foo')
+            collection = Collection('bar')
+            self.c.add_collection(collection, default=True)
 
     class getitem:
         "__getitem__"
@@ -298,6 +310,13 @@ class Collection_(Spec):
             t = Task(_func, default=True)
             self.c.add_task(t)
             eq_(self.c[''], t)
+
+        def honors_own_default_subcollection(self):
+            task = Task(_func, default=True)
+            sub = Collection('sub')
+            sub.add_task(task, default=True)
+            self.c.add_collection(sub, default=True)
+            eq_(self.c[''], task)
 
         def honors_subcollection_default_tasks_on_subcollection_name(self):
             sub = Collection.from_module(load('decorator'))


### PR DESCRIPTION
Hi,

I thought it would be a nice for subcollections to be defaults of their parent collection. Given that running a task and running the default task of a subcollection is basically the same (i.e. `invoke foo`), it makes sense that subcollections can be defaults if tasks can be defaults.

For example, if I have a collection named "tests" with a default task of "run_unit_tests", I might want the default of the top level namespace to be the default of "tests". With this PR, we can do:

```
tests_collection = Collection('tests')
tests_collection.add_task(Task(run_unit_tests), default=True)

namespace = Collection()
namespace.add_collection(tests_collection, default=True)
```

That way, I can simply type `invoke` and run my unit tests. 
