### PR TITLE
Expand paths which contain '..' or '.'

### DIFF
--- a/invoke/loader.py
+++ b/invoke/loader.py
@@ -71,7 +71,8 @@ class FilesystemLoader(Loader):
     @property
     def start(self):
         # Lazily determine default CWD
-        return self._start or os.getcwd()
+        # Also get realpath, so we can use .. here
+        return os.path.realpath(self._start) if self._start else os.getcwd()
 
     def find(self, name):
         # Accumulate all parent directories


### PR DESCRIPTION
It will be handy to invoke `invoke` from directory that lower than one containing `tasks.py`.