### PR TITLE
Prevent UnicodeErrors when forwarding child stdout to the console

### DIFF
--- a/invoke/runners.py
+++ b/invoke/runners.py
@@ -239,7 +239,10 @@ class Local(Runner):
                     yield data
             for data in codecs.iterdecode(get(), encoding, errors='replace'):
                 if not hide:
-                    dst.write(data)
+                    # Make sure no UnicodeError happens, even if the data is
+                    # garbled (e.g. due to encoding mismatch with the child).
+                    encoded_data = data.encode(dst.encoding, errors='replace')
+                    dst.buffer.write(encoded_data)
                     dst.flush()
                 cap.append(data)
 

--- a/invoke/runners.py
+++ b/invoke/runners.py
@@ -242,7 +242,8 @@ class Local(Runner):
                     # Make sure no UnicodeError happens, even if the data is
                     # garbled (e.g. due to encoding mismatch with the child).
                     encoded_data = data.encode(dst.encoding, errors='replace')
-                    dst.buffer.write(encoded_data)
+                    clean_data = encoded_data.decode(dst.encoding)
+                    dst.write(clean_data)
                     dst.flush()
                 cap.append(data)
 


### PR DESCRIPTION
In invoke.runners.Local, the stdout/stderr of child processes is read
and forwarded to the console (i.e. invoke's stdout/stderr). The incoming
data is read with ``locale.getdefaultencoding()``, while output happens with
``sys.stdout.encoding``.

If these two encodings differ, it may not be possible to write the
received data to stdout, e.g. if an UTF-8 Yen character is received, but
``sys.stdout.encoding`` is ``'latin1'`` or ``'ascii'``. If that happens, the
resulting exception causes the thread to end, and the child process
hangs due to the child filling its output buffer.

This is mostly a concern on Windows, where the preferred encoding and
the console I/O encoding often differ. In my testing, this fixes #241. The
console output has replacement characters, but invoke doesn't crash.