### PR TITLE
Pass in project directory when tasks module contains explicit namespace.

### DIFF
--- a/invoke/collection.py
+++ b/invoke/collection.py
@@ -163,7 +163,8 @@ class Collection(object):
                 # TODO: make this into Collection.clone() or similar
                 # Explicitly given name wins over root ns name which wins over
                 # actual module name.
-                ret = Collection(name or obj.name or module_name)
+                ret = Collection(name or obj.name or module_name,
+                                 loaded_from=loaded_from)
                 ret.tasks = copy.deepcopy(obj.tasks)
                 ret.collections = copy.deepcopy(obj.collections)
                 ret.default = copy.deepcopy(obj.default)


### PR DESCRIPTION
When a `tasks.py` module contains an explict Collection (named either `ns`
or `namespace`), the parent directory (used to find the project-specific
configuration file (e.g. `invoke.yaml`) is not passed in to the
Collection created from the factory method `Collection.from_module`.
This caused the file to not be found except when explicitly specified
with the -f flag. Compare to the similar Collection() invocation about
12 lines below this change.

Fix #234.