### PR TITLE
Feature #68: Only build bytecode files if option flag is used

### DIFF
--- a/invoke/cli.py
+++ b/invoke/cli.py
@@ -205,6 +205,12 @@ def parse(argv, collection=None, version=None):
             help="Enable debug output.",
         ),
         Argument(
+            names=('write-pyc',),
+            kind=bool,
+            default=False,
+            help="Enable creating .pyc files.",
+        ),
+        Argument(
             names=('echo', 'e'),
             kind=bool,
             default=False,
@@ -258,6 +264,10 @@ def parse(argv, collection=None, version=None):
     core = parse_gracefully(parser, argv[1:])
     debug("After core-args pass, leftover argv: {0!r}".format(core.unparsed))
     args = core[0].args
+
+    # Disable creating .pyc files, unless the write-pyc flag was given.
+    if not args['write-pyc'].value:
+        sys.dont_write_bytecode = True
 
     # Enable debugging from here on out, if debug flag was given.
     if args.debug.value:

--- a/tests/cli.py
+++ b/tests/cli.py
@@ -91,6 +91,7 @@ Core options:
   --complete                       Print tab-completion candidates for given
                                    parse remainder.
   --no-dedupe                      Disable task deduplication.
+  --write-pyc                      Enable creating .pyc files.
   -c STRING, --collection=STRING   Specify collection name to load.
   -d, --debug                      Enable debug output.
   -e, --echo                       Echo executed commands before running.


### PR DESCRIPTION
See: <https://github.com/pyinvoke/invoke/issues/68>. Since I generally like clean / less noisy project directories I think it's okay to default to not writing bytecode files (`*.pyc`) unless the option flag is set. Invoke tends to be pretty fast anyway and the possible speedup trough the bytecode files might be neglect able.

Not sure about tie ins to the [configuration system](http://invoke.readthedocs.org/en/latest/concepts/configuration.html)…
