### PR TITLE
Worked around a Python 2.6 bug whereby file streams don't respect encoding

### DIFF
--- a/invoke/runners.py
+++ b/invoke/runners.py
@@ -325,7 +325,18 @@ class Runner(object):
         # Decode stream using our generator & requested encoding
         for data in codecs.iterdecode(get(), self.encoding, errors='replace'):
             if not hide:
-                output.write(data)
+                # Workaround for the bug http://bugs.python.org/issue4947
+                # which affects Python 2.6 by ensuring that we encode to
+                # bytes when writing to any file stream
+                if (
+                    sys.version_info < (2, 7) and
+                    # We can't use isinstance because the file type doesn't
+                    # exist in Python 3.x and causes flake8 errors
+                    output.__class__.__name__ == 'file'
+                ):
+                    output.write(data.encode(self.encoding))
+                else:
+                    output.write(data)
                 output.flush()
             buffer_.append(data)
 


### PR DESCRIPTION
Hello again :smile: 

After many hours of trying to find the best way to solve this problem, here's my solution.  It ensures that Python 2.6 file streams will always encode to bytes before writing to the output stream.  This works around [Python issue 4947](http://bugs.python.org/issue4947).

You may reproduce the original problem as follows with Python 2.6:

```python
# encoding: utf-8
from invoke import task, run

@task
def output_strange_stuff():
    print '└──'

@task
def breakit():
    run('invoke output_strange_stuff', encoding='utf-8')
```

Then run:

```bash
invoke breakit
```

Feel free to ask any questions and thanks for the amazing tool! :smile: 

Cheers
Fotis