### PR TITLE
avoid IndexError when task has empty doc string

### DIFF
--- a/invoke/cli.py
+++ b/invoke/cli.py
@@ -348,7 +348,9 @@ def parse(argv, collection=None, version=None):
             task = collection[primary]
             help_ = ""
             if task.__doc__:
-                help_ = task.__doc__.lstrip().splitlines()[0]
+                _help = task.__doc__.lstrip().splitlines()
+                # if the __doc__ is empty, _help[0] raises IndexError
+                help_ = help_ if not _help else _help[0]
             pairs.append((name, help_))
 
         # Print


### PR DESCRIPTION
Hi, I have a task like you have in your docs

```
@task                                                                            
def build(sdist=False, rpm=False):                                               
    log.info("Running build command!") 
```

but I add an empty doc string (as a reminder to add docs later, of course... :) )

```
@task                                                                            
def build(sdist=False, rpm=False):                                               
    '''                                                                          
    '''                                                                          
    log.info("Running build command!") 
```

when I run `invoke` I get an `IndexError`

```
Traceback (most recent call last):
  File "/home/cward/virtenv_did/bin/invoke", line 11, in <module>
    sys.exit(main())
  File "/home/cward/virtenv_did/lib/python2.7/site-packages/invoke/cli.py", line 438, in main
    dispatch(sys.argv)
  File "/home/cward/virtenv_did/lib/python2.7/site-packages/invoke/cli.py", line 423, in dispatch
    args, collection, parser_contexts = parse(argv, version=version)
  File "/home/cward/virtenv_did/lib/python2.7/site-packages/invoke/cli.py", line 343, in parse
    help_ = task.__doc__.lstrip().splitlines()[0]
IndexError: list index out of range
```

when I add text to the doc string, invoke works as expected.

Here's my suggestion for a patch to fix this up.
