### PR TITLE
Added errors handler for forked PTY process

### DIFF
--- a/invoke/runners.py
+++ b/invoke/runners.py
@@ -458,15 +458,20 @@ class Local(Runner):
                     # terminal's window size appears to be.
                     # TODO: make subroutine?
                     winsize = struct.pack(b'HHHH', rows, cols, 0, 0)
-                    fcntl.ioctl(sys.stdout.fileno(), termios.TIOCSWINSZ, winsize)
+                    fcntl.ioctl(
+                        sys.stdout.fileno(),
+                        termios.TIOCSWINSZ,
+                        winsize
+                    )
                     # Use execv for bare-minimum "exec w/ variable # args"
-                    # behavior. No need for the 'p' (use PATH to find executable)
-                    # or 'e' (define a custom/overridden shell env) variants, for
-                    # now.
+                    # behavior. No need for the 'p' (use PATH to find
+                    # executable) # or 'e' (define a custom/overridden shell
+                    # env) variants, for now.
                     # TODO: use /bin/sh or whatever subprocess does. Only using
                     # bash for now because that's what we have been testing
                     # against.
-                    # TODO: also see if subprocess is using equivalent of execvp...
+                    # TODO: also see if subprocess is using equivalent of
+                    # execvp...
                     os.execv('/bin/bash', ['/bin/bash', '-c', command])
                 except Exception:
                     # Prevent process hanging when something wrong happened
@@ -476,6 +481,7 @@ class Local(Runner):
                     # We forcefully terminate this fork branch to simulate
                     # no-op `execv`
                     os._exit(1)
+ 
         else:
             self.process = Popen(
                 command,

--- a/invoke/runners.py
+++ b/invoke/runners.py
@@ -481,7 +481,6 @@ class Local(Runner):
                     # We forcefully terminate this fork branch to simulate
                     # no-op `execv`
                     os._exit(1)
- 
         else:
             self.process = Popen(
                 command,


### PR DESCRIPTION
Here is the issue reproduction:

```python
import invoke
invoke.run(u'echo \xff', pty=True)
```