### PR TITLE
Added list to core_args and added check for no-dedup. Program was ass…

### DIFF
--- a/invoke/program.py
+++ b/invoke/program.py
@@ -64,6 +64,12 @@ class Program(object):
                 help="Set default value of run()'s 'hide' kwarg.",
             ),
             Argument(
+                names=('list', 'l'),
+                kind=bool,
+                default=False,
+                help="List available tasks."
+            ),
+            Argument(
                 names=('pty', 'p'),
                 kind=bool,
                 default=False,
@@ -97,12 +103,6 @@ class Program(object):
             Argument(
                 names=('collection', 'c'),
                 help="Specify collection name to load."
-            ),
-            Argument(
-                names=('list', 'l'),
-                kind=bool,
-                default=False,
-                help="List available tasks."
             ),
             Argument(
                 names=('no-dedupe',),
@@ -229,7 +229,7 @@ class Program(object):
         if self.args.echo.value:
             run['echo'] = True
         tasks = {}
-        if self.args['no-dedupe'].value:
+        if 'no-dedupe' in self.args and self.args['no-dedupe'].value:
             tasks['dedupe'] = False
         overrides = {'run': run, 'tasks': tasks}
         # Stand up config object


### PR DESCRIPTION
…uming these would be a part of the flag structure which breaks creation of a Program.run where a namespace is passed in.

Consider the self contained python script ./foo

``` python
#!/usr/bin/env python

import sys

import invoke

@invoke.task
def build():
  print 'built!'

if __name__ == '__main__':
  namespace = invoke.Collection()
  namespace.add_task(build)
  program = invoke.Program(
    name='Foo',
    binary='foo',
    version='0.1',
    namespace=namespace
  )
  program.run(sys.argv)
```

`invoke.Program` would except because it assumes `self.args.list` was defined. The list operation makes sense to be a part of core_args in this use case. After fixing this `invoke.Program` excepts again assuming `self.args['no-dedup']` is defined.
