### PR TITLE
Fixes typo in docs/concepts/execution.rst

### DIFF
--- a/sites/docs/concepts/execution.rst
+++ b/sites/docs/concepts/execution.rst
@@ -157,7 +157,7 @@ to inclusion in pre/post tasks), will only be run once. Example task file::
         print("Packaging")
 
 With deduplication turned off (see below), the above would execute ``clean`` ->
-``build`` -> ``build`` again -> ``package``. With duplication, the double
+``build`` -> ``build`` again -> ``package``. With deduplication, the double
 ``build`` does not occur::
 
     $ invoke build package


### PR DESCRIPTION
Either this is obvious, or I'm very confused.