### PR TITLE
Add missing __deepcopy__ to Call class

### DIFF
--- a/invoke/tasks.py
+++ b/invoke/tasks.py
@@ -369,6 +369,9 @@ class Call(object):
     def __getattr__(self, name):
         return getattr(self.task, name)
 
+    def __deepcopy__(self, memo):
+        return self.clone()
+
     def __str__(self):
         aka = ""
         if self.called_as is not None and self.called_as != self.task.name:

--- a/tests/_support/namespacing.py
+++ b/tests/_support/namespacing.py
@@ -1,8 +1,12 @@
-from invoke import Collection, task
+from invoke import Collection, task, call
 
 from package import module
 
 @task
+def top_pre():
+    pass
+
+@task(call(top_pre))
 def toplevel():
     pass
 


### PR DESCRIPTION
It fixes #257.

(Having `__getattr__` without `__deepcopy__` causes infinite recursion in Python 3 when you deepcopy that object. A test is also updated to cause the error fixed in this commit.)

(See for example http://www.peterbe.com/plog/must__deepcopy__)