### PR TITLE
Output that is not hidden is forwarded to a stream on binary mode

### DIFF
--- a/invoke/runners.py
+++ b/invoke/runners.py
@@ -27,7 +27,8 @@ except ImportError:
 
 from .exceptions import Failure, ThreadException, ExceptionWrapper
 from .platform import (
-    WINDOWS, pty_size, character_buffered, ready_for_reading, read_byte, stream_in_binary_mode
+    WINDOWS, pty_size, character_buffered, ready_for_reading, read_byte,
+    stream_in_binary_mode,
 )
 from .util import has_fileno, isatty, debug
 

--- a/invoke/runners.py
+++ b/invoke/runners.py
@@ -27,7 +27,7 @@ except ImportError:
 
 from .exceptions import Failure, ThreadException, ExceptionWrapper
 from .platform import (
-    WINDOWS, pty_size, character_buffered, ready_for_reading, read_byte,
+    WINDOWS, pty_size, character_buffered, ready_for_reading, read_byte, stream_in_binary_mode
 )
 from .util import has_fileno, isatty, debug
 
@@ -383,8 +383,9 @@ class Runner(object):
             # combo of 'hide=stdout' + 'here is an explicit out_stream' means
             # out_stream is never written to, and that seems...odd.
             if not hide:
-                output.write(data)
-                output.flush()
+                with stream_in_binary_mode(output):
+                    output.write(data)
+                    output.flush()
             # Store in shared buffer so main thread can do things with the
             # result after execution completes.
             # NOTE: this is threadsafe insofar as no reading occurs until after


### PR DESCRIPTION
This will avoid universal newline conversion.

Only applies to windows file backed streams.
If the stream mode is TEXT on windows the output have extra `'\r'` characters.
Those extra carriage return codes can cause some trouble when the output is
redirected to a file for future processing.

The issue to be fixed is that the output generated on windows by subprocess does not have the universal newline handling by default (in my tests it was actually performed just after the call to `Popen.communicate` when the contents it sdtout/err are consumed) when printing the "live feed" from the subprocess the pair `'\r\n'` is subject to the newline text translation resulting in `'\r\r\n'`.

The change was to use a context manager so that on windows when a "fileno" is available `msvcrt.setmode` is used to set and restore the TEXT/BINARY mode of the stream so "text newline" translation does not take place.

