### PR TITLE
Handle keyboard interrupt gracefully

### DIFF
--- a/invoke/program.py
+++ b/invoke/program.py
@@ -268,6 +268,9 @@ class Program(object):
         try:
             self._parse(argv)
             self.execute()
+        except KeyboardInterrupt:
+            debug("Received keyboard interrupt")
+            sys.exit(130)
         except (Failure, Exit, ParseError) as e:
             debug("Received a possibly-skippable exception: {0!r}".format(e))
             # Print error message from parser if necessary.


### PR DESCRIPTION
Send SIGINT to child process, wait until it closes then exit with code 130 without stack trace.

It maybe fixes #152 

