### PR TITLE
escape error log in command failure diagnostics

### DIFF
--- a/invoke/exceptions.py
+++ b/invoke/exceptions.py
@@ -35,6 +35,7 @@ class Failure(Exception):
         if self.result.pty:
             err_label = "Stdout (pty=True; no stderr possible)"
             err_text = self.result.stdout
+        err_text = '\n'.join([repr(i)[1:-1] for i in err_text.splitlines()])
         return """Command execution failure!
 
 Exit code: {0}


### PR DESCRIPTION
This prevents Unicode appearing in the error log of failed commands throwing encoding exceptions (thus obscuring the actual error), by using `repr()` to enforce pure ASCII.

Maybe not the best solution, but a robust one.