### PR TITLE
Use inspect.signature to enable Python 3 only features when defining tasks

### DIFF
--- a/tests/collection.py
+++ b/tests/collection.py
@@ -229,7 +229,7 @@ class Collection_(Spec):
         def raises_ValueError_if_no_name_found(self):
             # Can't use a lambda here as they are technically real functions.
             class Callable(object):
-                def __call__(self):
+                def __call__(self, ctx):
                     pass
             self.c.add_task(Task(Callable()))
 


### PR DESCRIPTION
Fix  #372
