### PR TITLE
Fix Task and Call instance comparison bugs

### DIFF
--- a/invoke/tasks.py
+++ b/invoke/tasks.py
@@ -80,6 +80,11 @@ class Task(object):
         return str(self)
 
     def __eq__(self, other):
+        # Assumes that Tasks and Calls can not be compared,
+        # only Tasks with Tasks
+        # TODO: Review this assumption
+        if not isinstance(other, Task):
+            return False
         if self.name != other.name:
             return False
         # Functions do not define __eq__ but func_code objects apparently do.
@@ -371,6 +376,11 @@ class Call(object):
         # same args/kwargs should be considered same as an unnamed call of the
         # same Task with the same args/kwargs (e.g. pre/post task specified w/o
         # name). Ditto tasks with multiple aliases.
+        # Assumes that Calls and Tasks can not be compared,
+        # only Calls and Calls
+        # TODO: Review this assumption
+        if not isinstance(other, Call):
+            return False
         for attr in "task args kwargs".split():
             if getattr(self, attr) != getattr(other, attr):
                 return False

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -124,6 +124,11 @@ class Task_(Spec):
         t3 = Task(_func, name='bar')
         assert t1 != t3
 
+    def inequality_testing(self):
+        t1 = Task(_func, name='bar')
+        assert t1 is not None
+        assert t1 != _func  # comparison with non-Task type
+
     class attributes:
         def has_default_flag(self):
             eq_(Task(_func).is_default, False)
@@ -348,3 +353,5 @@ class Call_(Spec):
             eq_(clone.kwargs['key'], 'notval')
             eq_(orig.context['setting'], 'value')
             eq_(clone.context['setting'], 'notvalue')
+            assert orig is not None
+            assert orig != _func  # comparison with non-Call type


### PR DESCRIPTION
Add type checking so that only a Task instances can potentially equal
another Task instance. Same logic apply to Call instances.

Fixes #376