### PR TITLE
Added support for decorated tasks

### DIFF
--- a/invoke/tasks.py
+++ b/invoke/tasks.py
@@ -132,6 +132,9 @@ class Task(object):
         # TODO: __call__ exhibits the 'self' arg; do we manually nix 1st result
         # in argspec, or is there a way to get the "really callable" spec?
         func = body if isinstance(body, types.FunctionType) else body.__call__
+        # Handle decorated task functions
+        if hasattr(body, '__wrapped__'):
+            return self.argspec(body.__wrapped__)
         spec = inspect.getargspec(func)
         arg_names = spec.args[:]
         matched_args = [reversed(x) for x in [spec.args, spec.defaults or []]]


### PR DESCRIPTION
Currently, there is no way to use decorators with Invoke tasks:

``` python
import functools

def my_decorator(func):
    @functools.wraps(func)
    def wrapper(*args, **kwargs):
        print("Decorated call")
        return func(*args, **kwargs)
    return wrapper

@task
@my_decorator
def my_task(context, name, option1=1):
    print("Hello, %s!" % name)
```

This code will complain about missing `context` positional argument due to the fact that the `wrapper` defines `*args, **kwargs`.

Adding this small patch, `argspec` will respect `__wrapped__` field pointing to the decorated function.
