### PR TITLE
Change task list sorting

### DIFF
--- a/invoke/config.py
+++ b/invoke/config.py
@@ -27,7 +27,7 @@ else:
 
 from .env import Environment
 from .exceptions import UnknownFileType
-from .util import debug, merge_dicts, AmbiguousMergeError
+from .util import debug, merge_dicts
 from .platform import WINDOWS
 
 
@@ -594,5 +594,3 @@ class Config(DataProxy):
                 continue
             data[key] = value
         return data
-
-

--- a/invoke/program.py
+++ b/invoke/program.py
@@ -13,7 +13,7 @@ from .executor import Executor
 from .exceptions import (
     UnexpectedExit, CollectionNotFound, ParseError, Exit,
 )
-from .util import debug, enable_logging, sort_names
+from .util import debug, enable_logging, sort_names, sort_aliases
 from .platform import pty_size
 
 
@@ -538,7 +538,7 @@ class Program(object):
         pairs = []
         for primary in sort_names(task_names):
             # Add aliases
-            aliases = sort_names(task_names[primary])
+            aliases = sort_aliases(task_names[primary])
             name = primary
             if aliases:
                 name += " ({0})".format(', '.join(aliases))

--- a/invoke/util.py
+++ b/invoke/util.py
@@ -82,7 +82,10 @@ def _max_name_depth(subtree):
         return max([1 + _max_name_depth(subtree[k]) for k in subtree.keys()])
 
 def _sort_tree(subtree):
-    current_hierarchy_keys_sorted = sorted(subtree.keys(), key=lambda x: (_max_name_depth(subtree[x]), x))
+    current_hierarchy_keys_sorted = sorted(
+        subtree.keys(),
+        key=lambda x: (_max_name_depth(subtree[x]), x)
+    )
 
     sorted_levels = []
     for key in current_hierarchy_keys_sorted:

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,4 +1,4 @@
-from spec import Spec, eq_, ok_
+from spec import Spec, eq_
 
 from invoke.util import sort_names
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,19 @@
+from spec import Spec, eq_, ok_
+
+from invoke.util import sort_names
+
+class util_(Spec):
+    class sort_names_:
+        "sort_names"
+
+        def sorts_single_hierarchy_lexically(self):
+            eq_(sort_names(["a", "c", "b"]), ["a", "b", "c"])
+
+        def sorts_hierarchy_levels_lexically(self):
+            eq_(sort_names(["a", "c.b", "c.a", "b"]), ["a", "b", "c.a", "c.b"])
+
+        def group_hierachies_by_parent_then_depth_then_child(self):
+            eq_(
+                sort_names(["a.another.more", "a.first", "a.alpha", "b"]),
+                ["b", "a.alpha", "a.first", "a.another.more"]
+            )


### PR DESCRIPTION
Grouping by parent, and then sorting by depth/lexically makes the output dramatically more readable, this commit changes task lists sort to be:

1. By max hierarchy depth
2. Grouped by parent hierarchy name
3. Lexically

This (mostly) preserves the previous behaviour/requirement of top level tasks being more important, thus shorter, thus closer to the top of the list. Grouping tasks by their parent, however, makes deeply nested hierarchies easier to find/read. 

Fixes pyinvoke/invoke#402

This splits sorting for aliases (they're still sorted by depth, then lexically) from sorting for task names.