### PR TITLE
Change vendor imports so that it will use system wide modules if the the import from vendor directory fails.

### DIFF
--- a/invoke/collection.py
+++ b/invoke/collection.py
@@ -1,8 +1,14 @@
 import copy
 import types
 
-from .vendor import six
-from .vendor.lexicon import Lexicon
+try:
+    from .vendor import six
+    from .vendor.lexicon import Lexicon
+except ImportError:
+    # Use system wide modules
+    import six
+    from lexicon import Lexicon
+
 
 from .config import merge_dicts
 from .parser import Context as ParserContext

--- a/invoke/config.py
+++ b/invoke/config.py
@@ -3,11 +3,19 @@ import json
 import os
 from os.path import join, splitext, expanduser
 
-from .vendor import six
-if six.PY3:
-    from .vendor import yaml3 as yaml
-else:
-    from .vendor import yaml2 as yaml
+try:
+    from .vendor import six
+    if six.PY3:
+        from .vendor import yaml3 as yaml
+    else:
+        from .vendor import yaml2 as yaml
+except ImportError:
+    # Use system modules
+    import six
+    if six.PY3:
+        import yaml3 as yaml
+    else:
+        import yaml2 as yaml
 
 if six.PY3:
     try:

--- a/invoke/context.py
+++ b/invoke/context.py
@@ -1,7 +1,10 @@
 import getpass
 import re
 
-from invoke.vendor.six import raise_from, iteritems
+try:
+    from invoke.vendor.six import raise_from, iteritems
+except ImportError:
+    from six import raise_from, iteritems
 
 from .config import Config, DataProxy
 from .exceptions import Failure, AuthFailure, ResponseNotAccepted

--- a/invoke/env.py
+++ b/invoke/env.py
@@ -10,7 +10,10 @@ not be included in the Sphinx API documentation.
 
 import os
 
-from .vendor import six
+try:
+    from .vendor import six
+except ImportError:
+    import six
 
 from .exceptions import UncastableEnvVar, AmbiguousEnvVar
 from .util import debug

--- a/invoke/exceptions.py
+++ b/invoke/exceptions.py
@@ -10,7 +10,10 @@ from collections import namedtuple
 from traceback import format_exception
 from pprint import pformat
 
-from .vendor import six
+try:
+    from .vendor import six
+except ImportError:
+    import six
 
 
 class CollectionNotFound(Exception):

--- a/invoke/executor.py
+++ b/invoke/executor.py
@@ -4,7 +4,10 @@ from .parser import ParserContext
 from .util import debug
 from .tasks import Call, Task
 
-from .vendor import six
+try:
+    from .vendor import six
+except ImportError:
+    import six
 
 
 class Executor(object):

--- a/invoke/parser/context.py
+++ b/invoke/parser/context.py
@@ -1,6 +1,9 @@
 import itertools
 
-from ..vendor.lexicon import Lexicon
+try:
+    from ..vendor.lexicon import Lexicon
+except ImportError:
+    from lexicon import Lexicon
 
 from .argument import Argument
 

--- a/invoke/parser/parser.py
+++ b/invoke/parser/parser.py
@@ -1,7 +1,11 @@
 import copy
 
-from ..vendor.lexicon import Lexicon
-from ..vendor.fluidity import StateMachine, state, transition
+try:
+    from ..vendor.lexicon import Lexicon
+    from ..vendor.fluidity import StateMachine, state, transition
+except ImportError:
+    from lexicon import Lexicon
+    from fluidity import StateMachine, state, transition
 
 from ..util import debug
 from ..exceptions import ParseError

--- a/invoke/program.py
+++ b/invoke/program.py
@@ -5,7 +5,10 @@ import os
 import sys
 import textwrap
 
-from .vendor import six
+try:
+    from .vendor import six
+except ImportError:
+    import six
 
 from .complete import complete
 from .config import Config

--- a/invoke/runners.py
+++ b/invoke/runners.py
@@ -31,7 +31,10 @@ from .platform import (
 )
 from .util import has_fileno, isatty, ExceptionHandlingThread
 
-from .vendor import six
+try:
+    from .vendor import six
+except ImportError:
+    import six
 
 
 class Runner(object):

--- a/invoke/tasks.py
+++ b/invoke/tasks.py
@@ -7,7 +7,10 @@ from copy import deepcopy
 import inspect
 import types
 
-from .vendor import six
+try:
+    from .vendor import six
+except ImportError:
+    import six
 
 from .context import Context
 from .parser import Argument, translate_underscores


### PR DESCRIPTION

This will help maintaining pyinvoke package in most distro that does not accept bundled libraries (in my case Fedora).

The plan is to clear vendor/ and let pyinvoke use system provided modules.