### PR TITLE
bug #390 fallback to importing modules from sys.path

### DIFF
--- a/invoke/loader.py
+++ b/invoke/loader.py
@@ -86,11 +86,12 @@ class FilesystemLoader(Loader):
         # Make sure we haven't got duplicates on the end
         if parents[-1] == parents[-2]:
             parents = parents[:-1]
-        # Use find_module with our list of parents. ImportError from
-        # find_module means "couldn't find" not "found and couldn't import" so
-        # we turn it into a more obvious exception class.
+        # Use find_module with our list of parents with a fallback to sys.path
+        search_path = parents + sys.path
+        # ImportError from find_module means "couldn't find" not "found and
+        # couldn't import" so we turn it into a more obvious exception class.
         try:
-            tup = imp.find_module(name, parents)
+            tup = imp.find_module(name, search_path)
             debug("Found module: {0!r}".format(tup[1]))
             return tup
         except ImportError:

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`390` Fallback importing of a modules from sys.path. This has been
+  fixed, thanks to Paul Healy.
 * :bug:`430` Fallback importing of PyYAML when Invoke has been installed
   without its vendor directory, was still trying to import the vendorized
   module names (e.g. ``yaml2`` or ``yaml3`` instead of simply ``yaml``). This

--- a/tests/_support/syspathmodule/__init__.py
+++ b/tests/_support/syspathmodule/__init__.py
@@ -1,0 +1,5 @@
+from invoke import Collection
+import foo
+
+ns = Collection()
+ns.add_collection(foo)

--- a/tests/_support/syspathmodule/foo.py
+++ b/tests/_support/syspathmodule/foo.py
@@ -1,0 +1,5 @@
+from invoke import task
+
+@task
+def bar(ctx):
+  print "hello world\n"

--- a/tests/loader.py
+++ b/tests/loader.py
@@ -83,3 +83,7 @@ class FilesystemLoader_(Spec):
         # There's a basic tasks.py in tests/_support
         result = self.l.load()
         eq_(type(result), Collection)
+
+    def finds_modules_on_syspath(self):
+        "finds modules on sys.path"
+        FSLoader().find('syspathmodule')


### PR DESCRIPTION
This patch adds a fall back to searching sys.path for modules, which I think makes sense (allow a projects modules to be found before looking in sys.path).

However the documentation clearly says the opposite (First... Failing that...).

To follow the documentation, switch the search_path assignment to: search_path =  sys.path + parents

imp.find_module won't search sys.path by itself when an explicit path (second arg) is passed to it.