### PR TITLE
merge file objects using references (not copy.copy)

### DIFF
--- a/invoke/config.py
+++ b/invoke/config.py
@@ -995,6 +995,8 @@ def merge_dicts(base, updates):
             else:
                 if isinstance(base[key], dict):
                     raise _merge_error(base[key], value)
+                elif isinstance(value, file):
+                    base[key] = value
                 else:
                     base[key] = copy.copy(value)
         # New values get set anew
@@ -1003,6 +1005,8 @@ def merge_dicts(base, updates):
             # updates dict, which can lead to nasty state-bleed bugs otherwise
             if isinstance(value, dict):
                 base[key] = copy_dict(value)
+            elif isinstance(value, file):
+                base[key] = value
             # Non-dict values just get set straight
             else:
                 base[key] = copy.copy(value)

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :support:`-` Merge file objects in config object by reference.
 * :support:`-` Fixed some Python 2.6 incompatible string formatting that snuck
   in recently.
 * :feature:`-` Switched the order of the first two arguments of

--- a/tests/merge_dicts.py
+++ b/tests/merge_dicts.py
@@ -85,6 +85,11 @@ class merge_dicts_(Spec):
         # BUT that 'proj' remains UNTOUCHED
         eq_(proj['foo']['bar']['biz'], 'proj value')
 
+    def merge_file_types_by_reference(self):
+        d1 = {}
+        d2 = {'foo': open(__file__)}
+        merge_dicts(d1, d2)
+        eq_(d1['foo'].closed, False)
 
 class copy_dict_(Spec):
     def returns_deep_copy_of_given_dict(self):


### PR DESCRIPTION
copy.copy  "...does not copy types like ..., file, ..., or any similar types" 

file objects (e.g. err_stream... etc) end up closed following a dict merge.