### PR TITLE
Use getfullargspec if available

### DIFF
--- a/invoke/tasks.py
+++ b/invoke/tasks.py
@@ -132,7 +132,12 @@ class Task(object):
         # TODO: __call__ exhibits the 'self' arg; do we manually nix 1st result
         # in argspec, or is there a way to get the "really callable" spec?
         func = body if isinstance(body, types.FunctionType) else body.__call__
-        spec = inspect.getargspec(func)
+        # getargspec is deprecated on Python 3 and throws an error if 
+        # annotations are used.
+        try:
+            spec = inspect.getfullargspec(func)
+        except AttributeError:
+            spec = inspect.getargspec(func)
         arg_names = spec.args[:]
         matched_args = [reversed(x) for x in [spec.args, spec.defaults or []]]
         spec_dict = dict(zip_longest(*matched_args, fillvalue=NO_DEFAULT))

--- a/invoke/tasks.py
+++ b/invoke/tasks.py
@@ -132,7 +132,7 @@ class Task(object):
         # TODO: __call__ exhibits the 'self' arg; do we manually nix 1st result
         # in argspec, or is there a way to get the "really callable" spec?
         func = body if isinstance(body, types.FunctionType) else body.__call__
-        # getargspec is deprecated on Python 3 and throws an error if 
+        # getargspec is deprecated on Python 3 and throws an error if
         # annotations are used.
         try:
             spec = inspect.getfullargspec(func)


### PR DESCRIPTION
I like using annotations in Python as it allows my IDE to provide completions:
```python
@task
def test(c: Connection):
    c. # < IDE can now offer completions based on the Connection type
```

[`inspect.getargspec`](https://docs.python.org/3/library/inspect.html#inspect.getargspec) is deprecated since Python 3. It is still available on 3.6, however it throws an error when one uses function annotations:

> ValueError: Function has keyword-only parameters or annotations, use getfullargspec() API which can support them

The new api `inspect.getfullargspecs` is a drop-in replacement according to the stdlib authors:

> Deprecated since version 3.0: Use getfullargspec() for an updated API that is usually a drop-in replacement, but also correctly handles function annotations and keyword-only parameters.

This PR tries to use `getfullargspecs` and if that's not available, falls back to `getargspecs`.