### PR TITLE
Catch missing file and reflect it internally

### DIFF
--- a/invoke/config.py
+++ b/invoke/config.py
@@ -12,14 +12,10 @@ if six.PY3:
     except ImportError: # PyPy3
         from importlib._bootstrap import _SourceFileLoader as SourceFileLoader
     def load_source(name, path):
-        if not os.path.exists(path):
-            return {}
         return vars(SourceFileLoader('mod', path).load_module())
 else:
     import imp
     def load_source(name, path):
-        if not os.path.exists(path):
-            return {}
         return vars(imp.load_source('mod', path))
 
 from .env import Environment

--- a/tests/config.py
+++ b/tests/config.py
@@ -903,6 +903,9 @@ Valid real attributes: ['clear', 'clone', 'env_prefix', 'file_prefix', 'from_dat
 
         def yaml_prevents_yml_json_or_python(self):
             c = Config(system_prefix=join(CONFIGS_PATH, 'all-four/'))
+            ok_(c._system_found)
+            eq_(c._system_path, join(c._system_prefix, 'invoke.yaml'))
+            ok_(c._system != {})
             ok_('json-only' not in c)
             ok_('python_only' not in c)
             ok_('yml-only' not in c)
@@ -911,6 +914,9 @@ Valid real attributes: ['clear', 'clone', 'env_prefix', 'file_prefix', 'from_dat
 
         def yml_prevents_json_or_python(self):
             c = Config(system_prefix=join(CONFIGS_PATH, 'three-of-em/'))
+            ok_(c._system_found)
+            eq_(c._system_path, join(c._system_prefix, 'invoke.yml'))
+            ok_(c._system != {})
             ok_('json-only' not in c)
             ok_('python_only' not in c)
             ok_('yml-only' in c)
@@ -918,10 +924,18 @@ Valid real attributes: ['clear', 'clone', 'env_prefix', 'file_prefix', 'from_dat
 
         def json_prevents_python(self):
             c = Config(system_prefix=join(CONFIGS_PATH, 'json-and-python/'))
+            ok_(c._system_found)
+            eq_(c._system_path, join(c._system_prefix, 'invoke.json'))
+            ok_(c._system != {})
             ok_('python_only' not in c)
             ok_('json-only' in c)
             eq_(c.shared, 'json-value')
 
+        def missing_file_not_found(self):
+            c = Config(system_prefix=join(CONFIGS_PATH, 'missing/'))
+            ok_(not c._system_found)
+            eq_(c._system_path, None)
+            eq_(c._system, {})
 
     class clone:
         def preserves_basic_members(self):


### PR DESCRIPTION
If a given prefix does not result in any hits (yaml, yml, json, or py) then we should mark _{prefix}_found as False.

Both SourceFileLoader and imp.load_source kick up IOErrors when the file is missing.

Tested against python 2.7 and 3.5 on Linux.