### PR TITLE
Fixed bug where function equality compared text, not by ref...

### DIFF
--- a/invoke/tasks.py
+++ b/invoke/tasks.py
@@ -86,19 +86,8 @@ class Task(object):
     def __eq__(self, other):
         if self.name != other.name:
             return False
-        # Functions do not define __eq__ but func_code objects apparently do.
-        # (If we're wrapping some other callable, they will be responsible for
-        # defining equality on their end.)
-        if self.body == other.body:
-            return True
-        else:
-            try:
-                return (
-                    six.get_function_code(self.body) ==
-                    six.get_function_code(other.body)
-                )
-            except AttributeError:
-                return False
+            
+        return self.body == other.body
 
     def __hash__(self):
         # Presumes name and body will never be changed. Hrm.

--- a/tests/collection.py
+++ b/tests/collection.py
@@ -18,6 +18,15 @@ def _func(ctx):
     pass
 
 
+@task
+def eq_task1(ctx):
+    pass
+
+@task
+def eq_task2(ctx):
+    pass
+
+
 class Collection_(Spec):
     class init:
         "__init__"
@@ -79,13 +88,7 @@ class Collection_(Spec):
 
     class useful_special_methods:
         def _meh(self):
-            @task
-            def task1(ctx):
-                pass
-            @task
-            def task2(ctx):
-                pass
-            return Collection('meh', task1=task1, task2=task2)
+            return Collection('meh', task1=eq_task1, task2=eq_task2)
 
         def setup(self):
             self.c = self._meh()

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -133,6 +133,16 @@ class Task_(Spec):
         t3 = Task(_func, name='bar')
         assert t1 != t3
 
+    def equality_not_by_body_text_but_by_ref(self):
+        def make_task(name):
+            @task
+            def task1(ctx):
+                print(f'Hello {name}')
+
+            return task1
+
+        assert make_task('Hello') != make_task('World')
+
     class attributes:
         def has_default_flag(self):
             eq_(Task(_func).is_default, False)


### PR DESCRIPTION
… so the same functions with the same names and same body (but different closures) would be equal (and thus deduped, amongst other bad things).

I've found that the previous implementation was creating issues when you have a complex build tree that may have the same boilerplate code in it (but using different global args)... See the test I added as an example of the failure.

I think the test for "useful equality" was broken (fixed here)... The reason equality didn't "work" is because they were in fact not equal functions—they were different references, and could close on different things.