### PR TITLE
Help to get the fish completion filenames right

### DIFF
--- a/completion/fish
+++ b/completion/fish
@@ -1,5 +1,10 @@
 # Invoke (pyinvoke.org) tab-completion script to the fish shell
 # Copy it to the ~/.config/fish/completions directory
+# Or download it
+# curl https://raw.githubusercontent.com/pyinvoke/invoke/master/completion/fish --create-dirs -o  ~/.config/fish/completions/invoke.fish
+# for shorhand version change destination file name 
+# curl https://raw.githubusercontent.com/pyinvoke/invoke/master/completion/fish --create-dirs -o  ~/.config/fish/completions/inv.fish
+# then you need to change invoke here to inv
 
 function __complete_invoke
     invoke --complete -- (commandline --tokenize)


### PR DESCRIPTION
As per [fish completion doc](https://fishshell.com/docs/current/index.html#completion) a completion file should mach command and have .fish extension