### PR TITLE
Fix #407 Windows shell compatibility bug

### DIFF
--- a/invoke/config.py
+++ b/invoke/config.py
@@ -426,7 +426,7 @@ class Config(DataProxy):
         ``Config.global_defaults`` and applying `.merge_dicts` to the result,
         to add to or modify these values.
         """
-        return {
+        defaults = {
             # TODO: we document 'debug' but it's not truly implemented outside
             # of env var and CLI flag. If we honor it, we have to go around and
             # figure out at what points we might want to call
@@ -478,6 +478,12 @@ class Config(DataProxy):
                 'search_root': None,
             },
         }
+
+        # BUGFIX: (#407) If on Windows, use default shell setting.
+        if WINDOWS:
+            defaults['run']['shell'] = os.environ['COMSPEC']
+
+        return default_settings
 
     def __init__(
         self,

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* :bug:`407` Fix Windows shell compatibility bug. Change
+  `Config.global_defaults <invoke.config.Config.global_defaults>` so when
+  invoke is used on Windows, the default shell is set to Windows' default
+  shell setting.
 * :bug:`-` Iterable-type CLI args were actually still somewhat broken & were
   'eating' values after themselves in the parser stream (thus e.g. preventing
   parsing of subsequent tasks or flags.) This has been fixed.


### PR DESCRIPTION
Fixes #407, based on @mkusz [solution](https://github.com/pyinvoke/invoke/issues/371#issuecomment-332458981) in #371, by changing `Config.global_defaults <invoke.config.Config.global_defaults>`. This is done first, by checking if the OS is Windows, and if so, second, changing the value of `defaults['run']['shell']` to the Windows default shell setting, the value of the environment variable `COMSPEC`.