### PR TITLE
solution for #449 

### DIFF
--- a/invoke/__init__.py
+++ b/invoke/__init__.py
@@ -4,7 +4,7 @@ from .config import Config # noqa
 from .context import Context, MockContext  # noqa
 from .exceptions import ( # noqa
     AmbiguousEnvVar, ThreadException, ParseError, CollectionNotFound, # noqa
-    UnknownFileType, Exit, UncastableEnvVar, PlatformError, # noqa
+    UnknownFileType, Exit, UncastableEnvVar, PlatformError, UserError,# noqa
     ResponseNotAccepted, UnexpectedExit, AuthFailure, WatcherError, # noqa
 ) # noqa
 from .executor import Executor # noqa

--- a/invoke/exceptions.py
+++ b/invoke/exceptions.py
@@ -147,7 +147,6 @@ class UserError(ParseError):
     """
     def __init__(self, msg, context=None):
         super(UserError, self).__init__(msg)
-        self.context = context
 
 
 class Exit(Exception):

--- a/invoke/exceptions.py
+++ b/invoke/exceptions.py
@@ -138,6 +138,18 @@ class ParseError(Exception):
         self.context = context
 
 
+class UserError(ParseError):
+    """
+    An error arising from the parsing of command-line flags/arguments where
+    the cause is known to be a user error.
+
+    New users, forgetful users, drunk users, etc.
+    """
+    def __init__(self, msg, context=None):
+        super(UserError, self).__init__(msg)
+        self.context = context
+
+
 class Exit(Exception):
     """
     Simple stand-in for SystemExit that lets us gracefully exit.

--- a/invoke/exceptions.py
+++ b/invoke/exceptions.py
@@ -146,7 +146,7 @@ class UserError(ParseError):
     New users, forgetful users, drunk users, etc.
     """
     def __init__(self, msg, context=None):
-        super(UserError, self).__init__(msg)
+        super(UserError, self).__init__(msg, context)
 
 
 class Exit(Exception):

--- a/invoke/parser/parser.py
+++ b/invoke/parser/parser.py
@@ -8,7 +8,7 @@ except ImportError:
     from fluidity import StateMachine, state, transition
 
 from ..util import debug
-from ..exceptions import ParseError
+from ..exceptions import ParseError, UserError
 
 
 def is_flag(value):
@@ -268,7 +268,7 @@ class ParseMachine(StateMachine):
         # Ensure all of context's positional args have been given.
         if self.context and self.context.needs_positional_arg:
             err = "'{}' did not receive all required positional arguments!"
-            self.error(err.format(self.context.name))
+            self.user_error(err.format(self.context.name))
         if self.context and self.context not in self.result:
             self.result.append(self.context)
 
@@ -362,6 +362,9 @@ class ParseMachine(StateMachine):
 
     def error(self, msg):
         raise ParseError(msg, self.context)
+
+    def user_error(self, msg):
+        raise UserError(msg, self.context)
 
 
 class ParseResult(list):

--- a/invoke/program.py
+++ b/invoke/program.py
@@ -299,7 +299,7 @@ class Program(object):
             if isinstance(e, ParseError):
                 print(e, file=sys.stderr)
             if isinstance(e, UserError):
-                print(e, file=sys.stderr)
+                self.print_help()
             if isinstance(e, UnexpectedExit) and e.result.hide:
                 print(e, file=sys.stderr, end='')
             # Terminate execution unless we were told not to.

--- a/invoke/program.py
+++ b/invoke/program.py
@@ -299,7 +299,7 @@ class Program(object):
             if isinstance(e, ParseError):
                 print(e, file=sys.stderr)
             if isinstance(e, UserError):
-                self.print_help()
+                self.print_task_help(e.context.name)
             if isinstance(e, UnexpectedExit) and e.result.hide:
                 print(e, file=sys.stderr, end='')
             # Terminate execution unless we were told not to.

--- a/invoke/program.py
+++ b/invoke/program.py
@@ -11,7 +11,7 @@ from . import Collection, Config, Executor, FilesystemLoader
 from .complete import complete
 from .parser import Parser, ParserContext, Argument
 from .exceptions import (
-    UnexpectedExit, CollectionNotFound, ParseError, Exit,
+    UnexpectedExit, CollectionNotFound, ParseError, UserError, Exit,
 )
 from .util import debug, enable_logging, sort_names
 from .platform import pty_size
@@ -297,6 +297,8 @@ class Program(object):
             # prevents messy traceback but still clues interactive user into
             # problems.
             if isinstance(e, ParseError):
+                print(e, file=sys.stderr)
+            if isinstance(e, UserError):
                 print(e, file=sys.stderr)
             if isinstance(e, UnexpectedExit) and e.result.hide:
                 print(e, file=sys.stderr, end='')


### PR DESCRIPTION
These changes attempt to solve the issue by introducing a UserError subclass of ParseError that is thrown by parser.StateMachine instances when it is found that the invocation needs more positional args. Program instances look for UserError in the run() method and invoke their print_task_help(). 

The result for users is that the positional arg error is followed by the task help message.

Disclaimer: I just started using this package today, so my approach may be naive here. 