### PR TITLE
Context runner

### DIFF
--- a/invoke/collection.py
+++ b/invoke/collection.py
@@ -5,7 +5,7 @@ from .util import six, Lexicon, helpline
 
 from .config import merge_dicts, copy_dict
 from .parser import Context as ParserContext
-from .tasks import Task
+from .tasks import BaseTask
 
 
 class Collection(object):
@@ -112,7 +112,7 @@ class Collection(object):
             self._add_object(obj, name)
 
     def _add_object(self, obj, name=None):
-        if isinstance(obj, Task):
+        if isinstance(obj, BaseTask):
             method = self.add_task
         elif isinstance(obj, (Collection, types.ModuleType)):
             method = self.add_collection
@@ -226,7 +226,7 @@ class Collection(object):
                 return ret
         # Failing that, make our own collection from the module's tasks.
         tasks = filter(
-            lambda x: isinstance(x, Task),
+            lambda x: isinstance(x, BaseTask),
             vars(module).values()
         )
         # Again, explicit name wins over implicit one from module path

--- a/invoke/config.py
+++ b/invoke/config.py
@@ -479,9 +479,7 @@ class Config(DataProxy):
             # This doesn't live inside the 'run' tree; otherwise it'd make it
             # somewhat harder to extend/override in Fabric 2 which has a split
             # local/remote runner situation.
-            'runners': {
-                'local': Local,
-            },
+            'runner': Local,
             'sudo': {
                 'prompt': "[sudo] password: ",
                 'password': None,

--- a/invoke/config.py
+++ b/invoke/config.py
@@ -23,7 +23,6 @@ else:
 
 from .env import Environment
 from .exceptions import UnknownFileType
-from .runners import Local
 from .terminals import WINDOWS
 from .util import debug
 
@@ -476,10 +475,6 @@ class Config(DataProxy):
                 'watchers': [],
                 'echo_stdin': None,
             },
-            # This doesn't live inside the 'run' tree; otherwise it'd make it
-            # somewhat harder to extend/override in Fabric 2 which has a split
-            # local/remote runner situation.
-            'runner': Local,
             'sudo': {
                 'prompt': "[sudo] password: ",
                 'password': None,

--- a/invoke/context.py
+++ b/invoke/context.py
@@ -9,7 +9,7 @@ except ImportError:
 
 from .config import Config, DataProxy
 from .exceptions import Failure, AuthFailure, ResponseNotAccepted
-from .runners import Result
+from .runners import Local, Result
 from .watchers import FailingResponder
 
 
@@ -87,7 +87,7 @@ class BaseContext(DataProxy):
 
         .. versionadded:: 1.0
         """
-        runner = self.config.runner(self)
+        runner = self.runner(self)
         command = self._prefix_commands(command)
         return runner.run(command, **kwargs)
 
@@ -155,7 +155,7 @@ class BaseContext(DataProxy):
 
         .. versionadded:: 1.0
         """
-        runner = self.config.runner(self)
+        runner = self.runner(self)
         prompt = self.config.sudo.prompt
         password = kwargs.pop('password', self.config.sudo.password)
         user = kwargs.pop('user', self.config.sudo.user)
@@ -361,6 +361,7 @@ class Context(BaseContext):
         """
         config = config if config is not None else Config()
         super(Context, self).__init__(config)
+        self._set(runner=Local)
 
 
 class MockContext(Context):

--- a/invoke/context.py
+++ b/invoke/context.py
@@ -89,13 +89,7 @@ class Context(DataProxy):
 
         .. versionadded:: 1.0
         """
-        runner = self.config.runners.local(self)
-        return self._run(runner, command, **kwargs)
-
-    # NOTE: broken out of run() to allow for runner class injection in
-    # Fabric/etc, which needs to juggle multiple runner class types (local and
-    # remote).
-    def _run(self, runner, command, **kwargs):
+        runner = self.config.runner(self)
         command = self._prefix_commands(command)
         return runner.run(command, **kwargs)
 
@@ -163,11 +157,7 @@ class Context(DataProxy):
 
         .. versionadded:: 1.0
         """
-        runner = self.config.runners.local(self)
-        return self._sudo(runner, command, **kwargs)
-
-    # NOTE: this is for runner injection; see NOTE above _run().
-    def _sudo(self, runner, command, **kwargs):
+        runner = self.config.runner(self)
         prompt = self.config.sudo.prompt
         password = kwargs.pop('password', self.config.sudo.password)
         user = kwargs.pop('user', self.config.sudo.user)

--- a/invoke/context.py
+++ b/invoke/context.py
@@ -13,7 +13,7 @@ from .runners import Result
 from .watchers import FailingResponder
 
 
-class Context(DataProxy):
+class BaseContext(DataProxy):
     """
     Context-aware API wrapper & state-passing object.
 
@@ -32,12 +32,10 @@ class Context(DataProxy):
 
     .. versionadded:: 1.0
     """
-    def __init__(self, config=None):
+    def __init__(self, config):
         """
         :param config:
             `.Config` object to use as the base configuration.
-
-            Defaults to an anonymous/default `.Config` instance.
         """
         #: The fully merged `.Config` object appropriate for this context.
         #:
@@ -351,6 +349,18 @@ class Context(DataProxy):
         self.command_cwds.append(path)
         yield
         self.command_cwds.pop()
+
+
+class Context(BaseContext):
+    def __init__(self, config=None):
+        """
+        :param config:
+            `.Config` object to use as the base configuration.
+
+            Defaults to an anonymous/default `.Config` instance.
+        """
+        config = config if config is not None else Config()
+        super(Context, self).__init__(config)
 
 
 class MockContext(Context):

--- a/invoke/executor.py
+++ b/invoke/executor.py
@@ -112,7 +112,7 @@ class Executor(object):
         # especially given Executor is not designed to execute() >1 time at the
         # moment...
         for call in calls:
-            autoprint = call in direct and call.autoprint
+            autoprint = call in direct and call.task.autoprint
             args = call.args
             debug("Executing {!r}".format(call))
             # Hand in reference to our config, which will preserve user
@@ -217,7 +217,7 @@ class Executor(object):
             # TODO: we _probably_ don't even want the config in here anymore,
             # we want this to _just_ be about the recursion across pre/post
             # tasks or parameterization...?
-            ret.extend(self.expand_calls(call.pre))
+            ret.extend(self.expand_calls(call.task.pre))
             ret.append(call)
-            ret.extend(self.expand_calls(call.post))
+            ret.extend(self.expand_calls(call.task.post))
         return ret

--- a/invoke/executor.py
+++ b/invoke/executor.py
@@ -1,6 +1,7 @@
 from .util import six
 
 from .config import Config
+from .context import Context
 from .parser import ParserContext
 from .util import debug
 from .tasks import Call, Task
@@ -128,7 +129,7 @@ class Executor(object):
             # Get final context from the Call (which will know how to generate
             # an appropriate one; e.g. subclasses might use extra data from
             # being parameterized), handing in this config for use there.
-            context = call.make_context(config)
+            context = self.make_context(call, config)
             args = (context,) + args
             result = call.task(*args, **call.kwargs)
             if autoprint:
@@ -137,6 +138,12 @@ class Executor(object):
             # case, wherein one task obj maps to >1 result.
             results[call.task] = result
         return results
+
+    def make_context(self, call, config):
+        """
+        Generate a `.Context` appropriate for the call, with given config.
+        """
+        return Context(config=config)
 
     def normalize(self, tasks):
         """

--- a/invoke/tasks.py
+++ b/invoke/tasks.py
@@ -391,10 +391,6 @@ class Call(object):
         self.args = args or tuple()
         self.kwargs = kwargs or dict()
 
-    # TODO: just how useful is this? feels like maybe overkill magic
-    def __getattr__(self, name):
-        return getattr(self.task, name)
-
     def __deepcopy__(self, memo):
         return self.clone()
 

--- a/invoke/tasks.py
+++ b/invoke/tasks.py
@@ -22,21 +22,7 @@ from .parser import Argument, translate_underscores
 NO_DEFAULT = object()
 
 
-class Task(object):
-    """
-    Core object representing an executable task & its argument specification.
-
-    For the most part, this object is a clearinghouse for all of the data that
-    may be supplied to the `@task <invoke.tasks.task>` decorator, such as
-    ``name``, ``aliases``, ``positional`` etc, which appear as attributes.
-
-    In addition, instantiation copies some introspection/documentation friendly
-    metadata off of the supplied ``body`` object, such as ``__doc__``,
-    ``__name__`` and ``__module__``, allowing it to "appear as" ``body`` for
-    most intents and purposes.
-
-    .. versionadded:: 1.0
-    """
+class BaseTask(object):
     # TODO: store these kwarg defaults central, refer to those values both here
     # and in @task.
     # TODO: allow central per-session / per-taskmodule control over some of
@@ -120,10 +106,10 @@ class Task(object):
 
     def __call__(self, *args, **kwargs):
         # Guard against calling tasks with no context.
-        if not isinstance(args[0], Context):
-            err = "Task expected a Context as its first arg, got {} instead!"
+        if not isinstance(args[0], self.context_class):
+            err = "Task expected a {} as its first arg, got {} instead!"
             # TODO: raise a custom subclass _of_ TypeError instead
-            raise TypeError(err.format(type(args[0])))
+            raise TypeError(err.format(self.context_class, type(args[0])))
         result = self.body(*args, **kwargs)
         self.times_called += 1
         return result
@@ -252,6 +238,24 @@ class Task(object):
                     args.insert(0, args.pop(i))
                     break
         return args
+
+
+class Task(BaseTask):
+    """
+    Core object representing an executable task & its argument specification.
+
+    For the most part, this object is a clearinghouse for all of the data that
+    may be supplied to the `@task <invoke.tasks.task>` decorator, such as
+    ``name``, ``aliases``, ``positional`` etc, which appear as attributes.
+
+    In addition, instantiation copies some introspection/documentation friendly
+    metadata off of the supplied ``body`` object, such as ``__doc__``,
+    ``__name__`` and ``__module__``, allowing it to "appear as" ``body`` for
+    most intents and purposes.
+
+    .. versionadded:: 1.0
+    """
+    context_class = Context
 
 
 def task(*args, **kwargs):

--- a/invoke/tasks.py
+++ b/invoke/tasks.py
@@ -416,14 +416,6 @@ class Call(object):
                 return False
         return True
 
-    def make_context(self, config):
-        """
-        Generate a `.Context` appropriate for this call, with given config.
-
-        .. versionadded:: 1.0
-        """
-        return Context(config=config)
-
     def clone(self, into=None):
         """
         Return a standalone copy of this Call.

--- a/tests/config.py
+++ b/tests/config.py
@@ -7,7 +7,6 @@ from mock import patch, call
 import pytest
 from pytest import raises
 
-from invoke.runners import Local
 from invoke.config import Config
 from invoke.exceptions import (
     AmbiguousEnvVar, UncastableEnvVar, UnknownFileType
@@ -97,7 +96,6 @@ class Config_:
                     'warn': False,
                     'watchers': [],
                 },
-                'runner': Local,
                 'sudo': {
                     'password': None,
                     'prompt': '[sudo] password: ',
@@ -222,7 +220,7 @@ class Config_:
                 expected = """
 No attribute or config key found for 'nope'
 
-Valid keys: ['run', 'runner', 'sudo', 'tasks']
+Valid keys: ['run', 'sudo', 'tasks']
 
 Valid real attributes: ['clear', 'clone', 'env_prefix', 'file_prefix', 'from_data', 'global_defaults', 'load_base_conf_files', 'load_collection', 'load_defaults', 'load_overrides', 'load_project', 'load_runtime', 'load_shell_env', 'load_system', 'load_user', 'merge', 'pop', 'popitem', 'prefix', 'set_project_location', 'set_runtime_path', 'setdefault', 'update']
 """.strip() # noqa
@@ -570,7 +568,7 @@ Valid real attributes: ['clear', 'clone', 'env_prefix', 'file_prefix', 'from_dat
             assert c._project_path is None
             c.load_project()
             assert list(c._project.keys()) == []
-            defaults = ['tasks', 'run', 'runner', 'sudo']
+            defaults = ['tasks', 'run', 'sudo']
             assert set(c.keys()) == set(defaults)
 
         def project_location_can_be_set_after_init(self):

--- a/tests/config.py
+++ b/tests/config.py
@@ -97,9 +97,7 @@ class Config_:
                     'warn': False,
                     'watchers': [],
                 },
-                'runners': {
-                    'local': Local,
-                },
+                'runner': Local,
                 'sudo': {
                     'password': None,
                     'prompt': '[sudo] password: ',
@@ -224,7 +222,7 @@ class Config_:
                 expected = """
 No attribute or config key found for 'nope'
 
-Valid keys: ['run', 'runners', 'sudo', 'tasks']
+Valid keys: ['run', 'runner', 'sudo', 'tasks']
 
 Valid real attributes: ['clear', 'clone', 'env_prefix', 'file_prefix', 'from_data', 'global_defaults', 'load_base_conf_files', 'load_collection', 'load_defaults', 'load_overrides', 'load_project', 'load_runtime', 'load_shell_env', 'load_system', 'load_user', 'merge', 'pop', 'popitem', 'prefix', 'set_project_location', 'set_runtime_path', 'setdefault', 'update']
 """.strip() # noqa
@@ -572,7 +570,7 @@ Valid real attributes: ['clear', 'clone', 'env_prefix', 'file_prefix', 'from_dat
             assert c._project_path is None
             c.load_project()
             assert list(c._project.keys()) == []
-            defaults = ['tasks', 'run', 'runners', 'sudo']
+            defaults = ['tasks', 'run', 'runner', 'sudo']
             assert set(c.keys()) == set(defaults)
 
         def project_location_can_be_set_after_init(self):

--- a/tests/context.py
+++ b/tests/context.py
@@ -46,7 +46,7 @@ class Context_:
 
             def honors_runner_config_setting(self):
                 runner_class = Mock()
-                config = Config({'runners': {'local': runner_class}})
+                config = Config({'runner': runner_class})
                 c = Context(config)
                 c.run('foo')
                 assert runner_class.mock_calls == [
@@ -308,7 +308,7 @@ class Context_:
             Local = Mock()
             runner = Local.return_value
             context = Context(config=config) if config else Context()
-            context.config.runners.local = Local
+            context.config.runner = Local
             context.sudo('whoami', **kwargs)
             # Tease out the interesting bits - pattern/response - ignoring the
             # sentinel, etc for now.

--- a/tests/context.py
+++ b/tests/context.py
@@ -16,7 +16,7 @@ from invoke.context import BaseContext
 from _util import mock_subprocess, _Dummy
 
 
-local_path = 'invoke.config.Local'
+local_path = 'invoke.context.Local'
 
 
 class BaseContext_:
@@ -57,15 +57,6 @@ class Context_:
                 c.run('foo')
                 assert Local.mock_calls == [
                     call(c), call().run('foo')
-                ]
-
-            def honors_runner_config_setting(self):
-                runner_class = Mock()
-                config = Config({'runner': runner_class})
-                c = Context(config)
-                c.run('foo')
-                assert runner_class.mock_calls == [
-                    call(c), call().run('foo'),
                 ]
 
         def sudo(self):
@@ -289,8 +280,9 @@ class Context_:
         @mock_subprocess()
         def echo_hides_extra_sudo_flags(self):
             skip() # see TODO in sudo() re: clean output display
-            config = Config(overrides={'runner': _Dummy})
-            Context(config=config).sudo('nope', echo=True)
+            context = Context(config=Config())
+            context.runner = _Dummy
+            context.sudo('nope', echo=True)
             output = sys.stdout.getvalue()
             sys.__stderr__.write(repr(output) + "\n")
             assert "-S" not in output
@@ -323,7 +315,7 @@ class Context_:
             Local = Mock()
             runner = Local.return_value
             context = Context(config=config) if config else Context()
-            context.config.runner = Local
+            context.runner = Local
             context.sudo('whoami', **kwargs)
             # Tease out the interesting bits - pattern/response - ignoring the
             # sentinel, etc for now.

--- a/tests/context.py
+++ b/tests/context.py
@@ -11,11 +11,26 @@ from invoke import (
     AuthFailure, Context, Config, FailingResponder, ResponseNotAccepted,
     StreamWatcher, MockContext, Result,
 )
+from invoke.context import BaseContext
 
 from _util import mock_subprocess, _Dummy
 
 
 local_path = 'invoke.config.Local'
+
+
+class BaseContext_:
+    class init:
+        "__init__"
+        def takes_required_config_arg(self):
+            # Meh-tastic doesn't-barf tests. MEH.
+            BaseContext(config={'foo': 'bar'})
+            try:
+                BaseContext()
+            except TypeError:
+                pass
+            else:
+                assert False, "Did not raise TypeError!"
 
 
 class Context_:

--- a/tests/executor.py
+++ b/tests/executor.py
@@ -92,6 +92,13 @@ class Executor_:
             assert isinstance(args[0], Context)
             assert len(args) == 1
 
+    class make_context:
+        def creates_a_new_Context_from_given_config(self):
+            conf = Config(defaults={'foo': 'bar'})
+            ctx = self.executor.make_context(object(), conf)
+            assert isinstance(ctx, Context)
+            assert ctx.foo == 'bar'
+
     class basic_pre_post:
         "basic pre/post task functionality"
 

--- a/tests/task.py
+++ b/tests/task.py
@@ -1,7 +1,7 @@
 from mock import Mock
 from pytest import raises, skip
 
-from invoke import Context, Config, task, Task, Call, Collection
+from invoke import Context, task, Task, Call, Collection
 from invoke import FilesystemLoader as Loader
 
 from _util import support
@@ -368,17 +368,6 @@ class Call_:
         def skips_aka_if_explicit_name_same_as_task_name(self):
             call = Call(self.task, called_as='mytask')
             assert str(call) == "<Call 'mytask', args: (), kwargs: {}>"
-
-    class make_context:
-        def requires_config_argument(self):
-            with raises(TypeError):
-                Call(_).make_context()
-
-        def creates_a_new_Context_from_given_config(self):
-            conf = Config(defaults={'foo': 'bar'})
-            c = Call(_).make_context(conf)
-            assert isinstance(c, Context)
-            assert c.foo == 'bar'
 
     class clone:
         def returns_new_but_equivalent_object(self):


### PR DESCRIPTION
These are related to the changes in https://github.com/fabric/fabric/pull/1637. I won't go into incredible detail here, as the main discussion is on the fabric PR, but here is a brief overview of the changes:

- Add `BaseContext` which *expects* to be provided a config. `Context` is now simply providing the default config behavior.
- Add `BaseTask` which is configurable with a `context_class`. This is used to ensure fabric tasks are associated with `Connection`s, and invoke tasks with `Context`s. 
- In the associated PR, fabric tasks lose the `local` method in favor of a `local` context. It is no longer necessary for contexts to have multiple runners, or for the `runners` to be located in the config. This also eliminates the need for `_run` and `_sudo` (This isn't strictly necessary, but makes sense to me).
- `Call`s are not currently difficult to override. Moves context creation from the call to the executor. Also remove's the `Call.__getattr__` proxy to it's task. 