### PR TITLE
Add local_environ context manager.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,14 +19,6 @@ logging.basicConfig(level=logging.INFO)
 
 
 @pytest.fixture
-def environ():
-    old_environ = os.environ.copy()
-    yield
-    os.environ.clear()
-    os.environ.update(old_environ)
-
-
-@pytest.fixture
 def chdir_support():
     # Always do things relative to tests/_support
     os.chdir(support)


### PR DESCRIPTION
Also removed the unused environ test fixture which had similar functionality.

This is extracted from fabric/fabric#1738 and will be used in the Connection.socks_proxy() context manager.