### PR TITLE
Add `satisfies_minversion` function

### DIFF
--- a/invoke/__init__.py
+++ b/invoke/__init__.py
@@ -14,7 +14,7 @@ from .program import Program # noqa
 from .runners import ( # noqa
     Runner, Local, Failure, Result, # noqa
 ) # noqa
-from .tasks import task, call, Call, Task # noqa
+from .tasks import task, call, Call, Task, satisfies_minversion # noqa
 from .terminals import pty_size # noqa
 from .watchers import ( # noqa
     StreamWatcher, Responder, FailingResponder, # noqa

--- a/invoke/tasks.py
+++ b/invoke/tasks.py
@@ -469,7 +469,7 @@ def call(task, *args, **kwargs):
 
 def satisfies_minversion(version):
     """
-    Returns True when invoke's version is greater than or equal to `version`.
+    Returns True when invoke's version is greater than or equal to version.
     """
     from pkg_resources import parse_version
     from ._version import __version__ as invoke_version

--- a/invoke/tasks.py
+++ b/invoke/tasks.py
@@ -465,3 +465,12 @@ def call(task, *args, **kwargs):
     .. versionadded:: 1.0
     """
     return Call(task=task, args=args, kwargs=kwargs)
+
+
+def satisfies_minversion(version):
+    """
+    Returns True when invoke's version is greater than or equal to `version`.
+    """
+    from pkg_resources import parse_version
+    from ._version import __version__ as invoke_version
+    return parse_version(invoke_version) >= parse_version(version)


### PR DESCRIPTION
`satisfies_minversion` allows the user to ensure that a sufficient
version of `invoke` is being used.

    >>> satisfies_minversion("1.0")
    True
    >>> satisfies_minversion("0.1")
    True
    >>> satisfies_minversion("0.1.3")
    True
    >>> satisfies_minversion("0.1.3-r1")
    True
    >>> satisfies_minversion("1.0.1")
    False
    >>> satisfies_minversion("1.0-rc4")
    True
    >>> satisfies_minversion("1.1-rc4")
    False

Closes #509