### PR TITLE
Ensure dir change removed despite exceptions

### DIFF
--- a/invoke/context.py
+++ b/invoke/context.py
@@ -365,8 +365,10 @@ class Context(DataProxy):
         .. versionadded:: 1.0
         """
         self.command_cwds.append(path)
-        yield
-        self.command_cwds.pop()
+        try:
+            yield
+        finally:
+            self.command_cwds.pop()
 
 
 class MockContext(Context):


### PR DESCRIPTION
Hi, so I don't believe the current implementation of `cd()` handles exceptions. Take for example:

```python
try:
    with c.cd('subdir'):
        c.run('ls')
        raise Exception()
finally:
    c.run('ls')
```

The final `run()` call is executed in the same dir as the first because the dir change wasn't popped.

Note: Please test before merging (I'm writing in github to save time)