### PR TITLE
Rename link 'API Docs' to 'Documentation'

### DIFF
--- a/sites/www/conf.py
+++ b/sites/www/conf.py
@@ -17,7 +17,7 @@ if os.environ.get("READTHEDOCS") == "True":
     target = "http://docs.pyinvoke.org/en/latest/"
 intersphinx_mapping["docs"] = (target, None)
 
-# Sister-site links to API docs
+# Sister-site links to documentation
 html_theme_options["extra_nav_links"] = {
-    "API Docs": "http://docs.pyinvoke.org"
+    "Documentation": "http://docs.pyinvoke.org"
 }


### PR DESCRIPTION
The link API Docs is wrong, it's not just API documentation.
This should make the doc easier to find for new users