### PR TITLE
Added make-like checks to allow smarter deduping.

### DIFF
--- a/invoke/executor.py
+++ b/invoke/executor.py
@@ -90,6 +90,7 @@ class Executor(object):
         # Obtain copy of directly-given tasks since they should sometimes
         # behave differently
         direct = list(calls)
+
         # Expand pre/post tasks
         # TODO: may make sense to bundle expansion & deduping now eh?
         expanded = self.expand_calls(calls)
@@ -101,37 +102,59 @@ class Executor(object):
             dedupe = True
         # Dedupe across entire run now that we know about all calls in order
         calls = self.dedupe(expanded) if dedupe else expanded
+
         # Execute
         results = {}
         # TODO: maybe clone initial config here? Probably not necessary,
         # especially given Executor is not designed to execute() >1 time at the
         # moment...
-        for call in calls:
-            autoprint = call in direct and call.autoprint
-            args = call.args
-            debug("Executing {!r}".format(call))
-            # Hand in reference to our config, which will preserve user
-            # modifications across the lifetime of the session.
-            config = self.config
-            # But make sure we reset its task-sensitive levels each time
-            # (collection & shell env)
-            # TODO: load_collection needs to be skipped if task is anonymous
-            # (Fabric 2 or other subclassing libs only)
-            collection_config = self.collection.configuration(call.called_as)
-            config.load_collection(collection_config)
-            config.load_shell_env()
-            debug("Finished loading collection & shell env configs")
-            # Get final context from the Call (which will know how to generate
-            # an appropriate one; e.g. subclasses might use extra data from
-            # being parameterized), handing in this config for use there.
-            context = call.make_context(config)
-            args = (context,) + args
-            result = call.task(*args, **call.kwargs)
-            if autoprint:
-                print(result)
-            # TODO: handle the non-dedupe case / the same-task-different-args
-            # case, wherein one task obj maps to >1 result.
-            results[call.task] = result
+        for c in calls:
+            def run_call(call):
+                autoprint = call in direct and call.autoprint
+                args = call.args
+                debug("Executing {!r}".format(call))
+                # Hand in reference to our config, which will preserve user
+                # modifications across the lifetime of the session.
+                config = self.config
+                # But make sure we reset its task-sensitive levels each time
+                # (collection & shell env)
+                # TODO: load_collection needs to be skipped if task is anonymous
+                # (Fabric 2 or other subclassing libs only)
+                collection_config = self.collection.configuration(call.called_as)
+                config.load_collection(collection_config)
+                config.load_shell_env()
+                debug("Finished loading collection & shell env configs")
+                # Get final context from the Call (which will know how to generate
+                # an appropriate one; e.g. subclasses might use extra data from
+                # being parameterized), handing in this config for use there.
+                context = call.make_context(config)
+                args = (context,) + args
+                result = call.task(*args, **call.kwargs)
+                if autoprint:
+                    print(result)
+                # TODO: handle the non-dedupe case / the same-task-different-args
+                # TODO: REMOVEME - Is ^^ comment still accurate?
+                # case, wherein one task obj maps to >1 result.
+                results[call.task] = result
+                return result
+
+            failed_check = None
+            for check_task in c.checks:
+                check_call = Call(task=check_task)
+                result = run_call(check_call)
+                if not result:
+                    failed_check = check_call
+                    break
+
+            # This special case for len == 0 tells me that maybe we should rename
+            # checks to skip_if
+            if failed_check or len(c.checks) == 0:
+                debug("Running {} because {} returned {}".format(
+                    c.name, check_call.name, result))
+                run_call(c)
+            else:
+                debug("All {} checks for {} passed".format(len(c.checks), c.name))
+
         return results
 
     def normalize(self, tasks):
@@ -192,6 +215,10 @@ class Executor(object):
         .. versionadded:: 1.0
         """
         ret = []
+        if not getattr(calls, '__iter__', False):
+            raise ValueError("Expected iterable! Did you do "
+                "pre=mytask instead of pre=[mytask]?")
+
         for call in calls:
             # Normalize to Call (this method is sometimes called with pre/post
             # task lists, which may contain 'raw' Task objects)

--- a/invoke/tasks.py
+++ b/invoke/tasks.py
@@ -49,13 +49,14 @@ class Task(object):
         self,
         body,
         name=None,
-        aliases=(),
+        aliases=None,
         positional=None,
-        optional=(),
+        optional=None,
         default=False,
         auto_shortflags=True,
         help=None,
         pre=None,
+        checks=None,
         post=None,
         autoprint=False,
         iterable=None,
@@ -71,17 +72,18 @@ class Task(object):
         # Default name, alternate names, and whether it should act as the
         # default for its parent collection
         self._name = name
-        self.aliases = aliases
+        self.aliases = aliases or ()
         self.is_default = default
         # Arg/flag/parser hints
         self.positional = self.fill_implicit_positionals(positional)
-        self.optional = optional
+        self.optional = optional or ()
         self.iterable = iterable or []
         self.incrementable = incrementable or []
         self.auto_shortflags = auto_shortflags
         self.help = help or {}
         # Call chain bidness
         self.pre = pre or []
+        self.checks = checks or []
         self.post = post or []
         self.times_called = 0
         # Whether to print return value post-execution
@@ -319,37 +321,9 @@ def task(*args, **kwargs):
             )
         kwargs["pre"] = args
     # @task(options)
-    # TODO: why the heck did we originally do this in this manner instead of
-    # simply delegating to Task?! Let's just remove all this sometime & see
-    # what, if anything, breaks.
-    name = kwargs.pop("name", None)
-    aliases = kwargs.pop("aliases", ())
-    positional = kwargs.pop("positional", None)
-    optional = tuple(kwargs.pop("optional", ()))
-    iterable = kwargs.pop("iterable", None)
-    incrementable = kwargs.pop("incrementable", None)
-    default = kwargs.pop("default", False)
-    auto_shortflags = kwargs.pop("auto_shortflags", True)
-    help = kwargs.pop("help", {})
-    pre = kwargs.pop("pre", [])
-    post = kwargs.pop("post", [])
-    autoprint = kwargs.pop("autoprint", False)
-
     def inner(obj):
         obj = klass(
             obj,
-            name=name,
-            aliases=aliases,
-            positional=positional,
-            optional=optional,
-            iterable=iterable,
-            incrementable=incrementable,
-            default=default,
-            auto_shortflags=auto_shortflags,
-            help=help,
-            pre=pre,
-            post=post,
-            autoprint=autoprint,
             # Pass in any remaining kwargs as-is.
             **kwargs
         )

--- a/tests/task.py
+++ b/tests/task.py
@@ -60,7 +60,7 @@ class task_:
         skip()
 
     def sets_which_args_are_optional(self):
-        assert self.vanilla["optional_values"].optional == ("myopt",)
+        assert self.vanilla["optional_values"].optional == ["myopt",]
 
     def allows_annotating_args_as_positional(self):
         assert self.vanilla["one_positional"].positional == ["pos"]


### PR DESCRIPTION
This implements checks as documented here - https://bit.ly/2MP86Ic - and on #461.
Note the current limitation that all checks must be tasks.

Here's an example usage:
```
from invoke import task
from os.path import exists

@task
def already_built(ctx):
    print("checking...")
    return exists('x')

@task(checks=[already_built])
def build(ctx):
    print("creating x")
    ctx.run('touch x')

@task(pre=[build])
def read_file(ctx):
    print("found x!")
```

What do you think of renaming `checks` to `skip_if`? And hope you don't mind the little bit of cleanup I did in tasks.py. Thanks for the awesome library!