### PR TITLE
Add error message when can't find specified config

### DIFF
--- a/invoke/config.py
+++ b/invoke/config.py
@@ -773,9 +773,11 @@ class Config(DataProxy):
 
         :returns: ``None``.
 
+        :raises: ``ValueError`` If can't find specified config file.
+
         .. versionadded:: 1.0
         """
-        self._load_file(prefix="runtime", absolute=True, merge=merge)
+        self._load_file(prefix="runtime", absolute=True, merge=merge, safe=True)
 
     def load_shell_env(self):
         """
@@ -839,7 +841,7 @@ class Config(DataProxy):
         # Data loaded from the per-project config file.
         self._set(_project={})
 
-    def _load_file(self, prefix, absolute=False, merge=True):
+    def _load_file(self, prefix, absolute=False, merge=True, safe=False):
         # Setup
         found = "_{}_found".format(prefix)
         path = "_{}_path".format(prefix)
@@ -871,29 +873,40 @@ class Config(DataProxy):
         for filepath in paths:
             # Normalize
             filepath = expanduser(filepath)
+            exception = None
             try:
-                try:
-                    type_ = splitext(filepath)[1].lstrip(".")
-                    loader = getattr(self, "_load_{}".format(type_))
-                except AttributeError as e:
-                    msg = "Config files of type {!r} (from file {!r}) are not supported! Please use one of: {!r}"  # noqa
-                    raise UnknownFileType(
-                        msg.format(type_, filepath, self._file_suffixes)
-                    )
-                # Store data, the path it was found at, and fact that it was
-                # found
+                type_ = splitext(filepath)[1].lstrip(".")
+                loader = getattr(self, "_load_{}".format(type_))
+            except AttributeError as e:
+                msg = "Config files of type {!r} (from file {!r}) are not supported! Please use one of: {!r}"  # noqa
+                # Hold onto the exception, don't throw it yet.
+                # If we throw it here, we get 2 stacktraces. That's
+                # a little scary if you don't know our internals.
+                exception = UnknownFileType(
+                    msg.format(type_, filepath, self._file_suffixes)
+                )
+            # Make sure file exists without hiding bad suffix exception.
+            if not exception and safe and not os.path.exists(filepath):
+                    exception = ValueError(
+                        "Could not find config file {}".format(filepath))
+            if exception:
+                raise exception
+
+            # Store data, the path it was found at, and fact that it was
+            # found
+            try:
                 self._set(data, loader(filepath))
-                self._set(path, filepath)
-                self._set(found, True)
-                break
-            # Typically means 'no such file', so just note & skip past.
             except IOError as e:
+                # Typically means 'no such file', so just note & skip past.
                 # TODO: is there a better / x-platform way to detect this?
                 if "No such file" in e.strerror:
                     err = "Didn't see any {}, skipping."
                     debug(err.format(filepath))
                 else:
                     raise
+            self._set(path, filepath)
+            self._set(found, True)
+            break
         # Still None -> no suffixed paths were found, record this fact
         if getattr(self, path) is None:
             self._set(found, False)

--- a/tests/program.py
+++ b/tests/program.py
@@ -1226,19 +1226,6 @@ post2
 post2
 """.lstrip(),
                 )
-                # Flag beats runtime
-                expect(
-                    "-c integration -f dedupe.yaml --no-dedupe biz",
-                    out="""
-foo
-foo
-bar
-biz
-post1
-post2
-post2
-""".lstrip(),
-                )
 
         # * debug (top level?)
         # * hide (run.hide...lol)


### PR DESCRIPTION
Breaks a lot of tests, but they seem to pass even if I delete the
files that they depend on. So I think this just breaks already
broken tests. Fixes #560.