### PR TITLE
Stop parsecontexts deepcopy. Add *args **kwargs support.

### DIFF
--- a/invoke/collection.py
+++ b/invoke/collection.py
@@ -404,9 +404,10 @@ class Collection(object):
         result = []
         for primary, aliases in six.iteritems(self.task_names):
             task = self[primary]
+            args, vararg = task.get_arguments()
             result.append(
                 ParserContext(
-                    name=primary, aliases=aliases, args=task.get_arguments()
+                    name=primary, aliases=aliases, args=args, vararg=vararg
                 )
             )
         return result

--- a/invoke/executor.py
+++ b/invoke/executor.py
@@ -125,7 +125,9 @@ class Executor(object):
             # an appropriate one; e.g. subclasses might use extra data from
             # being parameterized), handing in this config for use there.
             context = call.make_context(config)
-            args = (context,) + args
+            # TODO 531 figure out why args is always blank here + how to
+            # space out *args past regular named args
+            args = (context,) + args + tuple(call.varargs)
             result = call.task(*args, **call.kwargs)
             if autoprint:
                 print(result)
@@ -144,15 +146,16 @@ class Executor(object):
         """
         calls = []
         for task in tasks:
-            name, kwargs = None, {}
+            name, varargs, kwargs = None, [], {}
             if isinstance(task, six.string_types):
                 name = task
             elif isinstance(task, ParserContext):
                 name = task.name
-                kwargs = task.as_kwargs
+                varargs, kwargs = task.as_varargs_and_kwargs
             else:
                 name, kwargs = task
-            c = Call(task=self.collection[name], kwargs=kwargs, called_as=name)
+            c = Call(task=self.collection[name],
+                     varargs=varargs, kwargs=kwargs, called_as=name)
             calls.append(c)
         if not tasks and self.collection.default is not None:
             calls = [Call(task=self.collection[self.collection.default])]


### PR DESCRIPTION
First step towards #378. See (#TODO 378)s.