### PR TITLE
allow Pathlib.path objects to be used with Context.cd()

### DIFF
--- a/invoke/context.py
+++ b/invoke/context.py
@@ -364,7 +364,8 @@ class Context(DataProxy):
 
         .. versionadded:: 1.0
         """
-        # NOTE this seems to be the simplest/most universal way to implement this functionality
+        # NOTE this seems to be the simplest/most universal way to implement
+        # this functionality
         path = str(path)
         self.command_cwds.append(path)
         yield

--- a/invoke/context.py
+++ b/invoke/context.py
@@ -364,6 +364,8 @@ class Context(DataProxy):
 
         .. versionadded:: 1.0
         """
+        # NOTE this seems to be the simplest/most universal way to implement this functionality
+        path = str(path)
         self.command_cwds.append(path)
         yield
         self.command_cwds.pop()

--- a/tests/context.py
+++ b/tests/context.py
@@ -191,12 +191,18 @@ class Context_:
 
         @patch(local_path)
         def cd_should_accept_pathlib_path_objects(self, Local):
-            from pathlib import Path
+            try:
+                from pathlib import Path
+            except ImportError:
+                # for Python 2.7 and pypy
+                # in this case, this test will be redundant
+                test_path = "foo"
+            else:
+                test_path = Path("foo")
 
             runner = Local.return_value
             c = Context()
 
-            test_path = Path("foo")
             with c.cd(test_path):
                 c.run("whoami")
 

--- a/tests/context.py
+++ b/tests/context.py
@@ -189,6 +189,20 @@ class Context_:
             assert runner.run.called, "run() never called runner.run()!"
             assert runner.run.call_args[0][0] == cmd
 
+        @patch(local_path)
+        def cd_should_accept_pathlib_path_objects(self, Local):
+            from pathlib import Path
+
+            runner = Local.return_value
+            c = Context()
+
+            test_path = Path("foo")
+            with c.cd(test_path):
+                c.run("whoami")
+
+            cmd = "cd foo && whoami"
+            assert runner.run.call_args[0][0] == cmd
+
     class prefix:
         def setup(self):
             self.escaped_prompt = re.escape(Config().sudo.prompt)


### PR DESCRIPTION
This addresses #454, implementing the simplest cast-to-`str` solution as originally suggested by @brutus, plus a basic unit test.