### PR TITLE
Exclude all __pycache__/pyc/pyo files from sdist (fix #586)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,4 +7,6 @@ recursive-exclude sites/*/_build *
 include dev-requirements.txt
 include tasks-requirements.txt
 recursive-include tests *
-recursive-exclude tests *.pyc *.pyo
+recursive-exclude * *.pyc *.pyo
+recursive-exclude **/__pycache__ *
+


### PR DESCRIPTION
Fixes #586 .

The best I could find on `recursive-exclude` documentation was https://docs.python.org/2/distutils/sourcedist.html#commands, and it wasn't really helpful.

This syntax works; I've verified it with bogus `*.pyc` and `*.pyo` files and `__pycache__` folder.  It does not strip more than it has to from the `.tar.gz`.

Tested on Debian 9.5 / Python 3.6 and Windows 7 / Python 3.7.