### PR TITLE
fix #357 - ValueError for annotated tasks

### DIFF
--- a/invoke/tasks.py
+++ b/invoke/tasks.py
@@ -151,7 +151,7 @@ class Task(object):
         # TODO: __call__ exhibits the 'self' arg; do we manually nix 1st result
         # in argspec, or is there a way to get the "really callable" spec?
         func = body if isinstance(body, types.FunctionType) else body.__call__
-        get_argspec = inspect.getfullargspec if hasattr(inspect, 'getfullargspec') else inspect.getargspec
+        get_argspec = getattr(inspect, "getfullargspec", inspect.getargspec)
         spec = get_argspec(func)
         arg_names = spec.args[:]
         matched_args = [reversed(x) for x in [spec.args, spec.defaults or []]]


### PR DESCRIPTION
As mentioned in #357 - using `getfullargspec` as recommended in the error itself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pyinvoke/invoke/606)
<!-- Reviewable:end -->
