### PR TITLE
Make Context.cd() accept Path objects

### DIFF
--- a/invoke/context.py
+++ b/invoke/context.py
@@ -366,6 +366,8 @@ class Context(DataProxy):
 
         .. versionadded:: 1.0
         """
+        # NOTE this seems to be the simplest/most universal way to implement this functionality
+        path = str(path)
         self.command_cwds.append(path)
         try:
             yield

--- a/invoke/context.py
+++ b/invoke/context.py
@@ -366,7 +366,8 @@ class Context(DataProxy):
 
         .. versionadded:: 1.0
         """
-        # NOTE this seems to be the simplest/most universal way to implement this functionality
+        # NOTE this seems to be the simplest/most universal way to implement
+        # this functionality
         path = str(path)
         self.command_cwds.append(path)
         try:

--- a/invoke/context.py
+++ b/invoke/context.py
@@ -366,8 +366,7 @@ class Context(DataProxy):
 
         .. versionadded:: 1.0
         """
-        # NOTE this seems to be the simplest/most universal way to implement
-        # this functionality
+        # path may be a Path object, turn into a string
         path = str(path)
         self.command_cwds.append(path)
         try:

--- a/tests/context.py
+++ b/tests/context.py
@@ -212,16 +212,15 @@ class Context_:
             try:
                 from pathlib import Path
             except ImportError:
-                # for Python 2.7 and pypy
-                # in this case, this test will be redundant
-                test_path = "foo"
-            else:
-                test_path = Path("foo")
+                # Path can be missing if we're on Python 2 or
+                # PyPy without pathlib or pathlib2 installed
+                if sys.version_info[0] == 2:
+                    skip("pathlib Path not available on Python 2")
 
             runner = Local.return_value
             c = Context()
 
-            with c.cd(test_path):
+            with c.cd(Path("foo")):
                 c.run("whoami")
 
             cmd = "cd foo && whoami"

--- a/tests/context.py
+++ b/tests/context.py
@@ -209,12 +209,18 @@ class Context_:
 
         @patch(local_path)
         def cd_should_accept_pathlib_path_objects(self, Local):
-            from pathlib import Path
+            try:
+                from pathlib import Path
+            except ImportError:
+                # for Python 2.7 and pypy
+                # in this case, this test will be redundant
+                test_path = "foo"
+            else:
+                test_path = Path("foo")
 
             runner = Local.return_value
             c = Context()
 
-            test_path = Path("foo")
             with c.cd(test_path):
                 c.run("whoami")
 

--- a/tests/context.py
+++ b/tests/context.py
@@ -207,6 +207,20 @@ class Context_:
             # When bug present, this would be "cd foo && ls"
             assert runner.run.call_args[0][0] == "ls"
 
+        @patch(local_path)
+        def cd_should_accept_pathlib_path_objects(self, Local):
+            from pathlib import Path
+
+            runner = Local.return_value
+            c = Context()
+
+            test_path = Path("foo")
+            with c.cd(test_path):
+                c.run("whoami")
+
+            cmd = "cd foo && whoami"
+            assert runner.run.call_args[0][0] == cmd
+
     class prefix:
         def setup(self):
             self.escaped_prompt = re.escape(Config().sudo.prompt)


### PR DESCRIPTION
This is a rebase (with minor modifications) of #583.

The original 583 stalled on AppVeyor, but that is disabled now so this should pass CI.

Closes #583 - original PR
Closes #681 - more recent but similar PR
Fixes #454 - original issue
Fixes #577 - duplicate issue
Fixes #658 - duplicate issue