### PR TITLE
Soften some edges on help text behavior (rebooted)

### DIFF
--- a/invoke/tasks.py
+++ b/invoke/tasks.py
@@ -256,7 +256,9 @@ class Task(object):
         if self.help:
             raise ValueError(
                 "Help field was set for params that didn't exist: {}".format(
-                    list(self.help.keys())))
+                    list(self.help.keys())
+                )
+            )
         return args
 
 

--- a/invoke/tasks.py
+++ b/invoke/tasks.py
@@ -217,7 +217,7 @@ class Task(object):
         # Help
         help_name_key = name if name in self.help else opts["attr_name"]
         if help_name_key in self.help:
-            opts["help"] = self.help[help_name_key]
+            opts["help"] = self.help.pop(help_name_key)
         return opts
 
     def get_arguments(self):
@@ -252,6 +252,11 @@ class Task(object):
                 if arg.name == posarg:
                     args.insert(0, args.pop(i))
                     break
+
+        if self.help:
+            raise ValueError(
+                "Help field was set for params that didn't exist: {}".format(
+                    list(self.help.keys())))
         return args
 
 

--- a/invoke/tasks.py
+++ b/invoke/tasks.py
@@ -215,7 +215,9 @@ class Task(object):
                 opts["kind"] = kind
             opts["default"] = default
         # Help
-        help_name_key = name if name in self.help else opts["attr_name"]
+        help_name_key = (name if name in self.help
+                         else opts["attr_name"] if "attr_name" in opts
+                         else None)
         if help_name_key in self.help:
             opts["help"] = self.help.pop(help_name_key)
         return opts

--- a/invoke/tasks.py
+++ b/invoke/tasks.py
@@ -215,8 +215,9 @@ class Task(object):
                 opts["kind"] = kind
             opts["default"] = default
         # Help
-        if name in self.help:
-            opts["help"] = self.help[name]
+        help_name_key = name if name in self.help else opts["attr_name"]
+        if help_name_key in self.help:
+            opts["help"] = self.help[help_name_key]
         return opts
 
     def get_arguments(self):

--- a/invoke/tasks.py
+++ b/invoke/tasks.py
@@ -215,9 +215,7 @@ class Task(object):
                 opts["kind"] = kind
             opts["default"] = default
         # Help
-        help_name_key = (name if name in self.help
-                         else opts["attr_name"] if "attr_name" in opts
-                         else None)
+        help_name_key = name if name in self.help else opts.get("attr_name")
         if help_name_key in self.help:
             opts["help"] = self.help.pop(help_name_key)
         return opts

--- a/tests/_support/decorators.py
+++ b/tests/_support/decorators.py
@@ -42,6 +42,26 @@ def punch(c, who, why):
     pass
 
 
+@task(
+    help={"parameter-with-underscores": "Help supplied with dashes"},
+    name="help_dashed",
+)
+def parameter_help_with_dashes_in_key(c, parameter_with_underscores):
+    # Note: keeping task 'name' short to fit on 79 columns
+    # in the --list output.
+    pass
+
+
+@task(
+    help={"parameter_with_underscores": "Supplied with underscores"},
+    name="help_uscored",
+)
+def parameter_help_with_underscores_in_key(c, parameter_with_underscores):
+    # Note: keeping the task 'name' short to fit on 79 columns
+    # in the --list output.
+    pass
+
+
 @task(positional=["pos"])
 def one_positional(c, pos, nonpos):
     pass

--- a/tests/collection.py
+++ b/tests/collection.py
@@ -575,6 +575,14 @@ class Collection_:
         def exposes_aliases(self):
             assert "mytask27" in self.aliases
 
+        def raises_ValueError_on_help_without_matching_parameter(self):
+            @task(help={"non-existing-parameter": "Help text"})
+            def _no_parameter(c):
+                pass
+
+            with raises(ValueError):
+                Collection(_no_parameter).to_contexts()
+
     class task_names:
         def setup(self):
             self.c = Collection.from_module(load("explicit_root"))

--- a/tests/program.py
+++ b/tests/program.py
@@ -695,6 +695,35 @@ Options:
             def complains_if_given_invalid_task_name(self):
                 expect("-h this", err="No idea what 'this' is!\n")
 
+        class per_parameter:
+            "per-parameter"
+
+            def displays_when_help_is_supplied_with_dashes_in_key(self):
+                expected = """
+Usage: invoke [--core-opts] help-dashed [--options] [other tasks here ...]
+
+Docstring:
+  none
+
+Options:
+  -p STRING, --parameter-with-underscores=STRING   Help supplied with dashes
+
+""".lstrip()
+                expect("-c decorators -h help-dashed --list", out=expected)
+
+            def displays_when_help_is_supplied_with_underscores_in_key(self):
+                expected = """
+Usage: invoke [--core-opts] help-uscored [--options] [other tasks here ...]
+
+Docstring:
+  none
+
+Options:
+  -p STRING, --parameter-with-underscores=STRING   Supplied with underscores
+
+""".lstrip()
+                expect("-c decorators -h help-uscored --list", out=expected)
+
     class task_list:
         "--list"
 


### PR DESCRIPTION
This is a rebase of #580, with added tests.

The original #580 failed on Travis due to code formatting (`black`).

New tests:

    Program
        help
            per parameter
                displays when help is supplied with dashes in key
                displays when help is supplied with underscores in key

    Collection
        to_contexts
            raises ValueError on help without matching parameter

Fixes #398 Bug report: no error on mismatched help keys and task arguments
Fixes #409 Bug report: help text on parameters with underscore
Closes #533 Duplicate bug report to #409
Closes #590 Duplicate feature request to #409
Closes #580 Original merge request