### PR TITLE
add os.sys.path to the parents search list

### DIFF
--- a/invoke/loader.py
+++ b/invoke/loader.py
@@ -114,7 +114,8 @@ class FilesystemLoader(Loader):
         # Accumulate all parent directories
         start = self.start
         debug("FilesystemLoader find starting at {!r}".format(start))
-        parents = [os.path.abspath(start)]
+        parents = os.sys.path
+        parents.append(os.path.abspath(start))
         parents.append(os.path.dirname(parents[-1]))
         while parents[-1] != parents[-2]:
             parents.append(os.path.dirname(parents[-1]))


### PR DESCRIPTION
loading a module that lives in my virtual environment.  when searching for tasks search os.sys.path first then look upward to the parent root.