### PR TITLE
Support for optional positional arguments

### DIFF
--- a/integration/main.py
+++ b/integration/main.py
@@ -62,6 +62,30 @@ class Main:
             _output_eq("inv print-name --name whatevs", "whatevs\n")
 
         @trap
+        def invocation_with_optional_positional_arg_as_positional(self):
+            _output_eq("inv -d print-hello Olivier", "Hello, Olivier!\n")
+
+        @trap
+        def invocation_with_optional_positional_arg_as_flag(self):
+            _output_eq("inv print-hello --name Olivier", "Hello, Olivier!\n")
+
+        @trap
+        def invocation_with_optional_positional_arg_no_value(self):
+            _output_eq("inv print-hello", "Hello, World!\n")
+
+        @trap
+        def invocation_with_multiple_positional_arg_single_optional(self):
+            _output_eq("inv print-addition 3 3", "6\n")
+
+        @trap
+        def invocation_with_multiple_positional_arg_single_optional_no_value(self):
+            _output_eq("inv print-addition 3", "5\n")
+
+        @trap
+        def invocation_with_multiple_positional_arg_single_optional_as_flag(self):
+            _output_eq("inv print-addition 3 --second 5", "8\n")
+
+        @trap
         def bad_collection_exits_nonzero(self):
             result = run("inv -c nope -l", warn=True)
             assert result.exited == 1

--- a/integration/tasks.py
+++ b/integration/tasks.py
@@ -18,3 +18,16 @@ def print_name(c, name):
 @task
 def print_config(c):
     print(c.foo)
+
+
+@task(positional=["name"])
+def print_hello(c, name="World", greeting="Hello"):
+    print("{}, {}!".format(greeting, name))
+
+
+@task(optional=["second"])
+def print_addition(c, first, second):
+    if not second:
+        second = 2
+
+    print(int(first) + int(second))

--- a/invoke/parser/parser.py
+++ b/invoke/parser/parser.py
@@ -305,11 +305,11 @@ class ParseMachine(StateMachine):
             )
         )
         # Ensure all of context's positional args have been given.
-        if self.context and self.context.missing_positional_args:
+        if self.context and self.context.missing_non_optional_positional_args:
             err = "'{}' did not receive required positional arguments: {}"
             names = ", ".join(
                 "'{}'".format(x.name)
-                for x in self.context.missing_positional_args
+                for x in self.context.missing_non_optional_positional_args
             )
             self.error(err.format(self.context.name, names))
         if self.context and self.context not in self.result:
@@ -362,7 +362,7 @@ class ParseMachine(StateMachine):
         # fail.
         tests = []
         # Unfilled posargs still exist?
-        tests.append(self.context and self.context.missing_positional_args)
+        tests.append(self.context and self.context.missing_non_optional_positional_args)
         # Value matches another valid task/context name?
         tests.append(value in self.contexts)
         if any(tests):
@@ -413,7 +413,7 @@ class ParseMachine(StateMachine):
 
     def see_positional_arg(self, value):
         for arg in self.context.positional_args:
-            if arg.value is None:
+            if not arg.got_value:
                 arg.value = value
                 break
 


### PR DESCRIPTION
This is an attempt at providing support for "optional posargs", i.e. positional arguments that can have a default value so that they can conveniently be omitted from the command line.

Fixes #159 and #554 (and possible other duplicate issues)

I've added some integration tests, but unit-testing the changes made in `ParserContext` and `ParseMachine` might be good too. (Note though that all existing tests pass without any change)

The implementation supports two ways of declaring an optional posarg:

**1. Optional arg explicitly declared positional**

```python
@task(positional=["name"])
def print_hello(c, name="World"):
    print("Hello, {}!".format(name))
```

This task can be called like so:

```
inv print-hello
> Hello, World!

inv print-hello Olivier
> Hello, Olivier!

inv print-hello --name Olivier
> Hello, Olivier!
```

**2. Positional arg explicitly declared optional**

Useful when there are several positional args and you don't want to list them all.  
Of course if you also have several optional args, then somehow you'll have to write down a full list of args 🙂 

```python
@task(optional=["second"])
def print_addition(c, first, second):
    if not second:
        second = 2

    print(int(first) + int(second))
```

This task can be called like so:

```
inv print-addition 3
> 5

inv print-addition 3 3
> 6

inv print-addition 3 --second 5
> 8
```