### PR TITLE
Fix Context.cd and .prefix behaviour on exception

### DIFF
--- a/invoke/context.py
+++ b/invoke/context.py
@@ -296,8 +296,10 @@ class Context(DataProxy):
         .. versionadded:: 1.0
         """
         self.command_prefixes.append(command)
-        yield
-        self.command_prefixes.pop()
+        try:
+            yield
+        finally:
+            self.command_prefixes.pop()
 
     @property
     def cwd(self):
@@ -365,8 +367,10 @@ class Context(DataProxy):
         .. versionadded:: 1.0
         """
         self.command_cwds.append(path)
-        yield
-        self.command_cwds.pop()
+        try:
+            yield
+        finally:
+            self.command_cwds.pop()
 
 
 class MockContext(Context):


### PR DESCRIPTION
When exception happens inside with statement it's escalated to the
contextmanager from with statement. By placing `self.command_cwds.pop()'
in finally block we make sure command prefixes are handled correctly on
exceptions in user code.