### PR TITLE
Namespace documentation leads to import error

### DIFF
--- a/sites/docs/concepts/namespaces.rst
+++ b/sites/docs/concepts/namespaces.rst
@@ -247,7 +247,7 @@ Tying them together is ``tasks/__init__.py``::
 
     from invoke import Collection
 
-    import release, docs
+    from tasks import release, docs
 
     ns = Collection()
     ns.add_collection(Collection.from_module(release))
@@ -315,8 +315,8 @@ sake. Just because it's stored in a module doesn't mean we must use
 
     from invoke import Collection
 
-    import docs
-    from release import release
+    from tasks import docs
+    from tasks.release import release
 
     ns = Collection()
     ns.add_collection(docs)
@@ -342,7 +342,7 @@ appropriate::
 
     from invoke import Collection
 
-    import docs, release
+    from tasks import docs, release
 
     ns = Collection(release.release, docs)
 


### PR DESCRIPTION
Hey, I noticed that the directory structure the following sections suggest leads to import error raised by `import release, docs`:
- http://docs.pyinvoke.org/en/1.2/concepts/namespaces.html#importing-modules-as-collections
- http://docs.pyinvoke.org/en/1.2/concepts/namespaces.html#mix-and-match
- http://docs.pyinvoke.org/en/1.2/concepts/namespaces.html#more-shortcuts

If I correctly understood your intentions, it should be `from tasks import release, docs`, since they're in package `tasks` because of the `__init__.py` file in the directory :)

## Reproducing
The first section
```bash
mkdir tasks

echo "from invoke import task
@task
def release(c):
    c.run(\"python setup.py sdist register upload\")" > tasks/release.py

echo "from invoke import task
@task
def build(c):
    c.run(\"sphinx-build docs docs/_build\")
@task
def clean(c):
    c.run(\"rm -rf docs/_build\")" > tasks/docs.py

echo "from invoke import Collection
import release, docs
ns = Collection()
ns.add_collection(Collection.from_module(release))
ns.add_collection(Collection.from_module(docs))" > tasks/__init__.py

invoke --list
```
output:
```
Traceback (most recent call last):
  File "/usr/local/bin/invoke", line 10, in <module>
    sys.exit(program.run())
  File "/usr/local/lib/python3.7/dist-packages/invoke/program.py", line 352, in run
    self.parse_collection()
  File "/usr/local/lib/python3.7/dist-packages/invoke/program.py", line 444, in parse_collection
    self.load_collection()
  File "/usr/local/lib/python3.7/dist-packages/invoke/program.py", line 661, in load_collection
    module, parent = loader.load(coll_name)
  File "/usr/local/lib/python3.7/dist-packages/invoke/loader.py", line 76, in load
    module = imp.load_module(name, fd, path, desc)
  File "/usr/lib/python3.7/imp.py", line 244, in load_module
    return load_package(name, filename)
  File "/usr/lib/python3.7/imp.py", line 216, in load_package
    return _load(spec)
  File "<frozen importlib._bootstrap>", line 696, in _load
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/tmp/pyinvoketest/tasks/__init__.py", line 2, in <module>
    import release, docs
ModuleNotFoundError: No module named 'release'
```

## Fix
```bash
sed -i 's/import release, docs/from tasks import release, docs/' tasks/__init__.py
invoke --list
```
output:
```
Available tasks:

  docs.build
  docs.clean
  release.release
```
Same applies for the other sections.

Hope I helped, thanks for the amazing package anyway!