### PR TITLE
Add explicit pypi package name and install command to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,10 @@
 Welcome to Invoke!
 ==================
 
+.. code:: shell
+
+   pip install invoke
+
 Invoke is a Python (2.7 and 3.4+) library for managing shell-oriented
 subprocesses and organizing executable Python code into CLI-invokable tasks. It
 draws inspiration from various sources (``make``/``rake``, Fabric 1.x, etc) to


### PR DESCRIPTION
`pip install pyinvoke` installs a similar but [not completely identical package](https://pypi.org/project/pyinvoke/) (currently at v1.0.4) 

I didn't realise this was `invoke`, not `pyinvoke`, and was thoroughly confused for a short while. 

The package name _is_ in the documentation, but is hiding behind a click in "Installing". 

(Somewhat related: pypi only has v1.2 of invoke; doesn't look like the latest release was pushed to pypi)

💖 

