### PR TITLE
Bugfix/issue 555 play nice with other decorator

### DIFF
--- a/invoke/tasks.py
+++ b/invoke/tasks.py
@@ -146,7 +146,6 @@ class Task(object):
           is a valid value on its own).
 
         .. versionadded:: 1.0
-        .. versionmodified:: 1.3.0
         The original method (version 1.0) was using inspect.getargspec()
         which makes problem when getting args a from decorated function.
         It is recommended to replace by inspect.signature() from Python 3.3

--- a/invoke/tasks.py
+++ b/invoke/tasks.py
@@ -145,11 +145,12 @@ class Task(object):
           `.NO_DEFAULT` (an 'empty' value distinct from None, since None
           is a valid value on its own).
 
-        .. versionadded:: 1.0
         The original method (version 1.0) was using inspect.getargspec()
         which makes problem when getting args a from decorated function.
         It is recommended to replace by inspect.signature() from Python 3.3
-        https://docs.python.org/3.6/library/inspect.html#inspect.getargspec
+        https://docs.python.org/3.3/library/inspect.html#inspect.getargspec
+
+        .. versionadded:: 1.0
         """
         if sys.version_info[0] < 3:
             return self.argspec_python2(body)

--- a/invoke/tasks.py
+++ b/invoke/tasks.py
@@ -163,8 +163,7 @@ class Task(object):
         try:
             context_arg = arg_names.pop(0)
         except IndexError:
-            # TODO: see TODO under __call__, this should be same type
-            raise TypeError("Tasks must have an initial Context argument!")
+            raise ValueError("Tasks must have an initial Context argument!")
         del spec_dict[context_arg]
         return arg_names, spec_dict
 

--- a/invoke/tasks.py
+++ b/invoke/tasks.py
@@ -157,7 +157,10 @@ class Task(object):
         for param in sig.parameters:
             arg = sig.parameters[param]
             arg_names.append(param)
-            spec_dict[param] = NO_DEFAULT if arg.default == inspect._empty else arg.default
+            if arg.default == inspect._empty:
+                spec_dict[param] = NO_DEFAULT
+            else:
+                spec_dict[param] = arg.default
 
         # Pop context argument
         try:

--- a/invoke/tasks.py
+++ b/invoke/tasks.py
@@ -157,7 +157,7 @@ class Task(object):
         for param in sig.parameters:
             arg = sig.parameters[param]
             arg_names.append(param)
-            if arg.default == inspect._empty:
+            if arg.default == inspect.Signature.empty:
                 spec_dict[param] = NO_DEFAULT
             else:
                 spec_dict[param] = arg.default

--- a/invoke/tasks.py
+++ b/invoke/tasks.py
@@ -176,7 +176,7 @@ class Task(object):
 
     def argspec_python2(self, body):
         """
-        For the compatible Python 2.x only.
+        For keeping the compatibility with Python 2.x only.
         """
         # Handle callable-but-not-function objects
         # TODO: __call__ exhibits the 'self' arg; do we manually nix 1st result

--- a/invoke/tasks.py
+++ b/invoke/tasks.py
@@ -145,14 +145,13 @@ class Task(object):
           `.NO_DEFAULT` (an 'empty' value distinct from None, since None
           is a valid value on its own).
 
-        The original method (version 1.0) was using inspect.getargspec()
-        which makes problem when getting args a from decorated function.
-        It is recommended to replace by inspect.signature() from Python 3.3
-        https://docs.python.org/3.3/library/inspect.html#inspect.getargspec
-
         .. versionadded:: 1.0
         """
         if sys.version_info[0] < 3:
+            # The original method (version 1.0) was using inspect.getargspec()
+            # which made a problem when getting args a from decorated function.
+            # It is recommended to replace by inspect.signature() from Python 3.3
+            # https://docs.python.org/3.3/library/inspect.html#inspect.getargspec
             return self.argspec_python2(body)
 
         sig = inspect.signature(body)

--- a/invoke/tasks.py
+++ b/invoke/tasks.py
@@ -191,7 +191,7 @@ class Task(object):
             context_arg = arg_names.pop(0)
         except IndexError:
             # TODO: see TODO under __call__, this should be same type
-            raise TypeError("Tasks must have an initial Context argument!")
+            raise ValueError("Tasks must have an initial Context argument!")
         del spec_dict[context_arg]
         return arg_names, spec_dict
 

--- a/invoke/tasks.py
+++ b/invoke/tasks.py
@@ -147,11 +147,11 @@ class Task(object):
 
         .. versionadded:: 1.0
         """
+        # The original method (version 1.0) uses inspect.getargspec()
+        # which gets problem with args a from decorated function.
+        # It's recommended to replace by inspect.signature() from Python 3.3
+        # https://docs.python.org/3.3/library/inspect.html#inspect.getargspec
         if sys.version_info[0] < 3:
-            # The original method (version 1.0) was using inspect.getargspec()
-            # which made a problem when getting args a from decorated function.
-            # It is recommended to replace by inspect.signature() from Python 3.3
-            # https://docs.python.org/3.3/library/inspect.html#inspect.getargspec
             return self.argspec_python2(body)
 
         sig = inspect.signature(body)

--- a/tests/task.py
+++ b/tests/task.py
@@ -294,7 +294,8 @@ class Task_:
                 class DecoIncrease(object):
                     """
                     This is an example of decorator as a class
-                    Decorator as class example is found at https://stackoverflow.com/a/45361673/1235074
+                    Decorator as class example is found at
+                    https://stackoverflow.com/a/45361673/1235074
                     """
                     def __init__(self, func):
                         update_wrapper(self, func)

--- a/tests/task.py
+++ b/tests/task.py
@@ -311,9 +311,8 @@ class Task_:
                     @task  # apply @task on top of others
                     @deco_increase_one
                     def foo(c):
-                        "My docstring"
+                        """My docstring"""
                         return 5
-
 
     class callability_under_class_decorators:
         def setup(self):

--- a/tests/task.py
+++ b/tests/task.py
@@ -299,7 +299,6 @@ class Task_:
 
         def python2_should_not_support_multi_decorators(self):
             def deco_increase_one(func):
-
                 @wraps(func)
                 def inner(*args, **kwargs):
                     return func(*args, **kwargs) + 1
@@ -308,6 +307,7 @@ class Task_:
 
             if sys.version_info[0] < 2:
                 with raises(ValueError):
+
                     @task  # apply @task on top of others
                     @deco_increase_one
                     def foo(c):

--- a/tests/task.py
+++ b/tests/task.py
@@ -259,9 +259,11 @@ class Task_:
                 """
                 This is an example of decorator as a function
                 """
+
                 @wraps(func)
                 def inner(*args, **kwargs):
                     return func(*args, **kwargs) + 1
+
                 return inner
 
             @deco_increase_one
@@ -297,6 +299,7 @@ class Task_:
                     Decorator as class example is found at
                     https://stackoverflow.com/a/45361673/1235074
                     """
+
                     def __init__(self, func):
                         update_wrapper(self, func)
                         self.func = func
@@ -308,6 +311,7 @@ class Task_:
                     def __call__(self, *args, **kwargs):
                         returned_value = self.func(*args, **kwargs)
                         return returned_value + value_up
+
                 return DecoIncrease
 
             @deco_increase(value_up=1)

--- a/tests/task.py
+++ b/tests/task.py
@@ -232,7 +232,8 @@ class Task_:
 
         def errors_if_no_first_arg_at_all(self):
             with raises(ValueError):
-
+                # keep this expectation not conflicted with
+                #   tests.collection.Collection_.add_task.raises_ValueError_if_no_name_found
                 @task
                 def mytask():
                     pass
@@ -266,14 +267,14 @@ class Task_:
             @deco_increase_one
             @task
             def foo(c):
-                "My docstring"
+                "Apply one decorator"
                 return 5
 
             @deco_increase_one
             @deco_increase_one
             @task
             def bar(c):
-                "My docstring"
+                "Apply multi decorators"
                 return 5
 
             self.task_foo = foo
@@ -311,14 +312,14 @@ class Task_:
             @deco_increase(value_up=1)
             @task
             def foo(c):
-                "My docstring"
+                "Apply one decorator"
                 return 5
 
             @deco_increase(value_up=2)
             @deco_increase(value_up=1)
             @task
             def bar(c):
-                "My docstring"
+                "Apply multi decorators"
                 return 5
 
             self.task_foo = foo

--- a/tests/task.py
+++ b/tests/task.py
@@ -1,3 +1,4 @@
+import sys
 from functools import wraps, update_wrapper, partial
 
 from mock import Mock
@@ -290,6 +291,30 @@ class Task_:
             context = Context()
             assert self.task_bar(context) == 7
 
+    class callability_with_python2_decorators:
+        """
+        PR 666 only adds the feature to Python 3.
+        Because Python 2 does not have inspect.signature()
+        """
+
+        def python2_should_not_support_multi_decorators(self):
+            def deco_increase_one(func):
+
+                @wraps(func)
+                def inner(*args, **kwargs):
+                    return func(*args, **kwargs) + 1
+
+                return inner
+
+            if sys.version_info[0] < 2:
+                with raises(ValueError):
+                    @task  # apply @task on top of others
+                    @deco_increase_one
+                    def foo(c):
+                        "My docstring"
+                        return 5
+
+
     class callability_under_class_decorators:
         def setup(self):
             def deco_increase(value_up=0):
@@ -314,8 +339,8 @@ class Task_:
 
                 return DecoIncrease
 
-            @deco_increase(value_up=1)
             @task
+            @deco_increase(value_up=1)
             def foo(c):
                 "Apply one decorator"
                 return 5

--- a/tests/task.py
+++ b/tests/task.py
@@ -229,7 +229,7 @@ class Task_:
                 mytask(5)
 
         def errors_if_no_first_arg_at_all(self):
-            with raises(TypeError):
+            with raises(ValueError):
 
                 @task
                 def mytask():


### PR DESCRIPTION
I made these changes to implement for:
https://github.com/pyinvoke/invoke/pull/246
https://github.com/pyinvoke/invoke/pull/399
https://github.com/pyinvoke/invoke/issues/555

It's more than 4 years from the date when people found it hard to apply to Invoke `@task` on other `@decorator`. The root cause of it is `inspect.getargspec` which couldn't handle decorated function. It's also recommended replacing by `inspect.signature` for a "more structured introspection API for callables" from [python 3.4](https://docs.python.org/3.4/library/inspect.html#inspect.getargspec).

I also keep the compatibility with Python 2.x by using the original function under the name `argspec_python2`.  New `argspec` will check if it is Python 2 and switch the flow to `argspec_python2` on runtime.