### PR TITLE
Allow to use a pathlib.Path instance as a `cd` argument

### DIFF
--- a/invoke/context.py
+++ b/invoke/context.py
@@ -366,7 +366,7 @@ class Context(DataProxy):
 
         .. versionadded:: 1.0
         """
-        self.command_cwds.append(path)
+        self.command_cwds.append(str(path))
         try:
             yield
         finally:

--- a/tests/context.py
+++ b/tests/context.py
@@ -207,6 +207,23 @@ class Context_:
             # When bug present, this would be "cd foo && ls"
             assert runner.run.call_args[0][0] == "ls"
 
+
+        @patch(local_path)
+        def should_convert_arg_to_string(self, Local):
+            class Path:
+                def __str__(self):
+                    return 'foo'
+
+            runner = Local.return_value
+
+            c = Context()
+            with c.cd(Path()):
+                c.run('ls -al')
+
+            cmd = "cd foo && ls -al"
+            assert runner.run.called, "run() never called runner.run()!"
+            assert runner.run.call_args[0][0] == cmd
+
     class prefix:
         def setup(self):
             self.escaped_prompt = re.escape(Config().sudo.prompt)

--- a/tests/context.py
+++ b/tests/context.py
@@ -207,18 +207,17 @@ class Context_:
             # When bug present, this would be "cd foo && ls"
             assert runner.run.call_args[0][0] == "ls"
 
-
         @patch(local_path)
         def should_convert_arg_to_string(self, Local):
             class Path:
                 def __str__(self):
-                    return 'foo'
+                    return "foo"
 
             runner = Local.return_value
 
             c = Context()
             with c.cd(Path()):
-                c.run('ls -al')
+                c.run("ls -al")
 
             cmd = "cd foo && ls -al"
             assert runner.run.called, "run() never called runner.run()!"


### PR DESCRIPTION
``` python
from pathlib import Path

basedir = Path(__file__).parent.resolve()

@task
def deploy(ctx):
    with ctx.cd(basedir):
        ctx.run("ls -al")
```

Will fail with  

```
File "/python/lib/python3.7/site-packages/invoke/context.py", line 94, in run
    return self._run(runner, command, **kwargs)
  File "/python/lib/python3.7/site-packages/invoke/context.py", line 100, in _run
    command = self._prefix_commands(command)
  File "/python/lib/python3.7/site-packages/invoke/context.py", line 242, in _prefix_commands
    current_directory = self.cwd
  File "/python/lib/python3.7/site-packages/invoke/config.py", line 123, in __getattr__
    raise AttributeError(err)
AttributeError: No attribute or config key found for 'cwd'
```

This is due that when getting the `cwd` value it expects to have an string type value.

By converting any cd argument to an string, it now supports to use pathlib.Path instances.

