### PR TITLE
'fix-UnexceptedExit-printed'

### DIFF
--- a/invoke/exceptions.py
+++ b/invoke/exceptions.py
@@ -64,14 +64,14 @@ class Failure(Exception):
         .. versionadded:: 1.3
         """
         already_printed = " already printed"
-        if "stdout" not in self.result.hide:
+        if "stdout" in self.result.hide:
             stdout = already_printed
         else:
             stdout = self.result.tail("stdout")
         if self.result.pty:
             stderr = " n/a (PTYs have no stderr)"
         else:
-            if "stderr" not in self.result.hide:
+            if "stderr" in self.result.hide:
                 stderr = already_printed
             else:
                 stderr = self.result.tail("stderr")


### PR DESCRIPTION
Result.hide‘s default value is False，it’s a empty tuple, it's means weren't hidden from the user when the generating command executed.
When have a UnexceptionExit, in default(hide = False), it should be printed 10 lines stdout and 10 lines stderr, but beacuse here is not in, so in default, it printed 'already printed' twice.
