### PR TITLE
Fix wrong assert check

### DIFF
--- a/tests/config.py
+++ b/tests/config.py
@@ -643,7 +643,7 @@ Valid real attributes: ['clear', 'clone', 'env_prefix', 'file_prefix', 'from_dat
             c._load_yml = Mock(side_effect=IOError(2, "aw nuts"))
             c.set_runtime_path("is-a.yml")  # Triggers use of _load_yml
             c.load_runtime()
-            mock_debug.assert_has_call("Didn't see any is-a.yml, skipping.")
+            mock_debug.assert_any_call("Didn't see any is-a.yml, skipping.")
 
         @raises(IOError)
         def non_missing_file_IOErrors_are_raised(self):


### PR DESCRIPTION
The assert_has_call method does not exist but its use did not cause an
issue on older versions of unittest because it was created on demand.

More recent versions of unittest has catch this type of error:
https://bugs.python.org/issue21238

The fix is to use the correct method, which in this case is assert_any_call.