### PR TITLE
Allow passing a list to ctx.run

### DIFF
--- a/tests/runners.py
+++ b/tests/runners.py
@@ -338,6 +338,11 @@ class Runner_:
             # TODO: vendor & use a color module
             assert sys.stdout.getvalue() == "\x1b[1;37mmy command\x1b[0m\n"
 
+        @trap
+        def concats(self):
+            self._run(["my", "command"], echo=True)
+            assert "my command" in sys.stdout.getvalue()
+
     class dry_running:
         @trap
         def sets_echo_to_True(self):
@@ -1506,6 +1511,17 @@ class Local_:
 
     def _runner(self, *args, **kwargs):
         return _runner(*args, **dict(kwargs, klass=_FastLocal))
+
+    class run:
+        @mock_subprocess(insert_Popen=True)
+        def supports_string_as_command(self, mock_Popen):
+            self._run("echo hello")
+            assert mock_Popen.call_args_list[0][0][0] == "echo hello"
+        
+        @mock_subprocess(insert_Popen=True)
+        def supports_list_as_command(self, mock_Popen):
+            self._run(["echo", "hello"])
+            assert mock_Popen.call_args_list[0][0][0] == ["echo", "hello"]
 
     class pty:
         @mock_pty()


### PR DESCRIPTION
Only uses `shlex_quote` when we absolutely have to (echoing and `execve` for PTY).

More or less reviving #2 and #341 (which back then had trouble with Sphinx not supporting multiple types for a parameter).