### PR TITLE
Inject command into Results returned by a MockContext

### DIFF
--- a/invoke/context.py
+++ b/invoke/context.py
@@ -461,14 +461,21 @@ class MockContext(Context):
         # result? E.g. filling in .command, etc? Possibly useful for debugging
         # if one hits unexpected-order problems with what they passed in to
         # __init__.
-        return self._yield_result("__run", command)
+        result = self._yield_result("__run", command)
+        if result.command == "":
+            result.command = command
+        return result
+
 
     def sudo(self, command, *args, **kwargs):
         # TODO: this completely nukes the top-level behavior of sudo(), which
         # could be good or bad, depending. Most of the time I think it's good.
         # No need to supply dummy password config, etc.
         # TODO: see the TODO from run() re: injecting arg/kwarg values
-        return self._yield_result("__sudo", command)
+        result = self._yield_result("__sudo", command)
+        if result.command == "":
+            result.command = command
+        return result
 
     def set_result_for(self, attname, command, result):
         """


### PR DESCRIPTION
A small pull request to make MockContext's `.run()` and `.sudo()` return `Results` with the `command` attribute set.

From my own use cases, the `command` attribute is the only one I ever seem to need. I frequently create a layer of simple tasks, upon which I create more complex tasks that will call the others. Proper unit testing requires me to check that all parameters are properly passed to the lower tasks, ie. that they contruct the right command for the `ctx.run()`.

Therefore, in this use case, I cannot provide `command` to the `Result()` constructor **and** I need some way to get at the actual command so I can test it.

So I wrote these small modifications to the `MockContext.run()` and `MockContext.sudo()` methods. If a `command` is given to the `Result()` constructor, it is of course retained, otherwise the actual command is injected.

While I believe that this is the most likely use case for such an injection, I would keep the TODO remarks about maybe one day injecting other args/kwargs as well, as I don't believe we can be 100% certain those will never be useful...