### PR TITLE
Update config.py

### DIFF
--- a/invoke/config.py
+++ b/invoke/config.py
@@ -905,6 +905,9 @@ class Config(DataProxy):
 
     def _load_yaml(self, path):
         with open(path) as fd:
+            if hasattr(yaml, "safe_load"):
+                # Use safe loader if available
+                return yaml.safe_load(fd)
             return yaml.load(fd)
 
     def _load_yml(self, path):


### PR DESCRIPTION
Current versions of PyYAML display a YAMLLoadWarning, indicating that using the default loader is unsafe. Trying to stay compatible with old versions that might not offer the save_load method.