### PR TITLE
feat: Add ability to source task arg from ealier call

### DIFF
--- a/invoke/tasks.py
+++ b/invoke/tasks.py
@@ -17,8 +17,18 @@ else:
     from itertools import izip_longest as zip_longest
 
 
+class SingletonObject:
+    def __copy__(self, *args, **kwargs):
+        return self
+    def __deepcopy__(self, *args, **kwargs):
+        return self
+
+
 #: Sentinel object representing a truly blank value (vs ``None``).
 NO_DEFAULT = object()
+#: Sentinel objects which don't change when copied
+NOT_SET = SingletonObject()
+FROM_PARENT = SingletonObject()
 
 
 class Task(object):


### PR DESCRIPTION
```python
from invoke import task, call
from invoke.tasks import NOT_SET, FROM_PARENT


@task
def bar(ctx, baz=1):
    print(baz)


@task(pre=[call(bar, baz=FROM_PARENT)])
def foo(ctx, baz=1):
    ctx.run("echo Hello")
```

```shell
$ invoke foo
1
Hello

$ invoke foo --baz=99
99
Hello
```