### PR TITLE
Fix path quoting

### DIFF
--- a/tests/context.py
+++ b/tests/context.py
@@ -1,6 +1,7 @@
 import os
 import pickle
 import re
+import shlex
 import sys
 
 from mock import patch, Mock, call
@@ -150,6 +151,18 @@ class Context_:
         def home(self):
             self.c.command_cwds = ["a", "~b", "c"]
             assert self.c.cwd == os.path.join("~b", "c")
+
+        def spaces(self):
+            self.c.command_cwds = ["a b", "c"]
+            assert self.c.cwd == shlex.quote(os.path.join("a b", "c"))
+
+        def special(self):
+            self.c.command_cwds = ["a(b)", "c"]
+            assert self.c.cwd == shlex.quote(os.path.join("a(b)", "c"))
+
+        def special_home(self):
+            self.c.command_cwds = ["~a", "b(c)"]
+            assert self.c.cwd == os.path.join("~a", shlex.quote("b(c)"))
 
     class cd:
         def setup(self):


### PR DESCRIPTION
Currently path quoting for the `Context.cd` command fails when the path contains special characters, see https://stackoverflow.com/q/63225018/1968.

Rather than implement a complete path quoting routine from scratch, this PR leverages Python’s builtin `shlex.quote`. This requires one adjustment, since `shlex.quote` treats a starting `~` as an ordinary character, and the resulting, quoted path would no longer be subject to expansion (cf. `echo ~` vs. `echo '~').