### PR TITLE
Don't fail on empty docstrings

### DIFF
--- a/invoke/util.py
+++ b/invoke/util.py
@@ -169,7 +169,8 @@ def helpline(obj):
     docstring = obj.__doc__
     if not docstring or docstring == type(obj).__doc__:
         return None
-    return docstring.lstrip().splitlines()[0]
+    lines =  docstring.lstrip().splitlines()
+    return lines[0] if lines else ""
 
 
 class ExceptionHandlingThread(threading.Thread):

--- a/invoke/util.py
+++ b/invoke/util.py
@@ -169,7 +169,7 @@ def helpline(obj):
     docstring = obj.__doc__
     if not docstring or docstring == type(obj).__doc__:
         return None
-    lines =  docstring.lstrip().splitlines()
+    lines = docstring.lstrip().splitlines()
     return lines[0] if lines else ""
 
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -9,9 +9,10 @@ class util:
 
             assert helpline(foo) is None
 
-        def is_None_if_empty_docstring(self):
+        def is_None_if_docstring_only_whitespace(self):
             def foo(c):
-                ""
+                """
+                """
 
             assert helpline(foo) is None
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -9,6 +9,12 @@ class util:
 
             assert helpline(foo) is None
 
+        def is_None_if_empty_docstring(self):
+            def foo(c):
+                ""
+
+            assert helpline(foo) is None
+
         def is_entire_thing_if_docstring_one_liner(self):
             def foo(c):
                 "foo!"


### PR DESCRIPTION
Hello,

Invoke v1.5.0 on Python 2.7. Methods defined without a docstring, or with an empty docstring, cause an exception at `.splitlines()[0]`. This doesn't cause a problem running the subcommands themselves, but `--list` fails.

Example: run `fab --list` with this:
```
import fabric

@fabric.tasks.task
def foo(ctx):
    """
    """
    print("noop")
```