### PR TITLE
Adding support for a custom output format via run.echo

### DIFF
--- a/invoke/config.py
+++ b/invoke/config.py
@@ -481,6 +481,7 @@ class Config(DataProxy):
                 "hide": None,
                 "in_stream": None,
                 "out_stream": None,
+                "output_format": "\033[1;37m{command}\033[0m\n",
                 "pty": False,
                 "replace_env": False,
                 "shell": shell,

--- a/invoke/runners.py
+++ b/invoke/runners.py
@@ -282,6 +282,16 @@ class Runner(object):
             should be written. If ``None`` (the default), ``sys.stdout`` will
             be used.
 
+        :param output_format:
+            A string, which when passed to Python's inbuilt ``.format`` method,
+            will change the format of the output when ``run.echo`` is set to
+            true.
+            
+            Currently, only ``{command}`` is supported as a parameter.
+            
+            Defaults to ``\033[1;37m{command}\033[0m\n`` (prints the full
+            command in ANSI-escaped bold).
+
         :param err_stream:
             Same as ``out_stream``, except for standard error, and defaulting
             to ``sys.stderr``.
@@ -370,7 +380,12 @@ class Runner(object):
         # of stop() and then we can nix this. Ugh!
         self.stop()
         self.stop_timer()
-
+    
+    def echo(self, command):
+        sys.stdout.write(self.opts['output_format'].format(
+            command=command,
+        ))
+    
     def _setup(self, command, kwargs):
         """
         Prepare data on ``self`` so we're ready to start running.
@@ -385,7 +400,7 @@ class Runner(object):
         self.encoding = self.opts["encoding"] or self.default_encoding()
         # Echo running command (wants to be early to be included in dry-run)
         if self.opts["echo"]:
-            print("\033[1;37m{}\033[0m".format(command))
+            self.echo(command)
         # Prepare common result args.
         # TODO: I hate this. Needs a deeper separate think about tweaking
         # Runner.generate_result in a way that isn't literally just this same

--- a/tests/config.py
+++ b/tests/config.py
@@ -104,6 +104,7 @@ class Config_:
                     "hide": None,
                     "in_stream": None,
                     "out_stream": None,
+                    "output_format": "\033[1;37m{command}\033[0m\n",
                     "pty": False,
                     "replace_env": False,
                     "shell": "/bin/bash",

--- a/tests/runners.py
+++ b/tests/runners.py
@@ -338,6 +338,11 @@ class Runner_:
             # TODO: vendor & use a color module
             assert sys.stdout.getvalue() == "\x1b[1;37mmy command\x1b[0m\n"
 
+        @trap
+        def uses_custom_format(self):
+            self._run("my command", echo=True, settings={"run": {"output_format": 'AA{command}ZZ\n'}})
+            assert sys.stdout.getvalue() == "AAmy commandZZ\n"
+
     class dry_running:
         @trap
         def sets_echo_to_True(self):


### PR DESCRIPTION
The format of the output of fabric2 doesn't quite do it for me; rather than forcing a change that makes it different for everyone, I thought allowing users to customise the output format might be a good idea. It currently only supports wrapping the `command` passed to it, but I will happily look into ways of determining things like whether it's `sudo` or not (and maybe caching the current unadulterated command somewhere to display prettily like fabric1).

- [x] Added supporting test(s)
- [x] Added supporting documentation

Please let me know if there's anything else I've missed.

Cheers,
David