### PR TITLE
Read from Popen stdout and stdin instead of fd

### DIFF
--- a/invoke/runners.py
+++ b/invoke/runners.py
@@ -1224,13 +1224,13 @@ class Local(Runner):
                 # "end of output" logic in code using reader functions.
                 data = None
         else:
-            data = os.read(self.process.stdout.fileno(), num_bytes)
+            data = self.process.stdout.read(num_bytes)
         return data
 
     def read_proc_stderr(self, num_bytes):
         # NOTE: when using a pty, this will never be called.
         # TODO: do we ever get those OSErrors on stderr? Feels like we could?
-        return os.read(self.process.stderr.fileno(), num_bytes)
+        return self.process.stderr.read(num_bytes)
 
     def _write_proc_stdin(self, data):
         # NOTE: parent_fd from os.fork() is a read/write pipe attached to our
@@ -1289,6 +1289,7 @@ class Local(Runner):
                 stdout=PIPE,
                 stderr=PIPE,
                 stdin=PIPE,
+                bufsize=0,
             )
 
     def kill(self):

--- a/tests/_util.py
+++ b/tests/_util.py
@@ -129,6 +129,8 @@ class MockSubprocess(object):
         process.returncode = self.exit
         process.stdout.fileno.return_value = 1
         process.stderr.fileno.return_value = 2
+        process.stdout = self.out_file
+        process.stderr = self.err_file
         # If requested, mock isatty to fake out pty detection
         if self.isatty is not None:
             sys_stdin.isatty = Mock(return_value=self.isatty)


### PR DESCRIPTION
### Description

Reading directly from file descriptors doesn't handle non-blocking IO, which is an issue when it's patched with gevent. 

### Changes

1. Make Popen stream unbuffered, it was failing a couple of integration tests when it's buffered I assume because it tries to read number of bytes more than what's already available.
2. Read from stdout and stderr in Popen and add them to the mock in tests.


### Related issues

https://github.com/pyinvoke/invoke/issues/799