### PR TITLE
refactor: implement absolute imports

### DIFF
--- a/invoke/__init__.py
+++ b/invoke/__init__.py
@@ -1,8 +1,8 @@
-from ._version import __version_info__, __version__  # noqa
-from .collection import Collection  # noqa
-from .config import Config  # noqa
-from .context import Context, MockContext  # noqa
-from .exceptions import (  # noqa
+from invoke._version import __version_info__, __version__  # noqa
+from invoke.collection import Collection  # noqa
+from invoke.config import Config  # noqa
+from invoke.context import Context, MockContext  # noqa
+from invoke.exceptions import (  # noqa
     AmbiguousEnvVar,
     AuthFailure,
     CollectionNotFound,
@@ -19,14 +19,14 @@ from .exceptions import (  # noqa
     WatcherError,
     CommandTimedOut,
 )
-from .executor import Executor  # noqa
-from .loader import FilesystemLoader  # noqa
-from .parser import Argument, Parser, ParserContext, ParseResult  # noqa
-from .program import Program  # noqa
-from .runners import Runner, Local, Failure, Result, Promise  # noqa
-from .tasks import task, call, Call, Task  # noqa
-from .terminals import pty_size  # noqa
-from .watchers import FailingResponder, Responder, StreamWatcher  # noqa
+from inoke.executor import Executor  # noqa
+from inoke.loader import FilesystemLoader  # noqa
+from inoke.parser import Argument, Parser, ParserContext, ParseResult  # noqa
+from inoke.program import Program  # noqa
+from inoke.runners import Runner, Local, Failure, Result, Promise  # noqa
+from inoke.tasks import task, call, Call, Task  # noqa
+from inoke.terminals import pty_size  # noqa
+from inoke.watchers import FailingResponder, Responder, StreamWatcher  # noqa
 
 
 def run(command, **kwargs):

--- a/invoke/collection.py
+++ b/invoke/collection.py
@@ -1,11 +1,11 @@
 import copy
 import types
 
-from .util import six, Lexicon, helpline
+from invoke.util import six, Lexicon, helpline
 
-from .config import merge_dicts, copy_dict
-from .parser import Context as ParserContext
-from .tasks import Task
+from invoke.config import merge_dicts, copy_dict
+from invoke.parser import Context as ParserContext
+from invoke.tasks import Task
 
 
 class Collection(object):

--- a/invoke/completion/complete.py
+++ b/invoke/completion/complete.py
@@ -7,9 +7,9 @@ import os
 import re
 import shlex
 
-from ..exceptions import Exit, ParseError
-from ..parser import Parser
-from ..util import debug, task_name_sort_key
+from invoke.exceptions import Exit, ParseError
+from invoke.parser import Parser
+from invoke.util import debug, task_name_sort_key
 
 
 def complete(names, core, initial_context, collection):

--- a/invoke/config.py
+++ b/invoke/config.py
@@ -4,11 +4,11 @@ import os
 import types
 from os.path import join, splitext, expanduser
 
-from .env import Environment
-from .exceptions import UnknownFileType, UnpicklableConfigMember
-from .runners import Local
-from .terminals import WINDOWS
-from .util import debug, six, yaml
+from invoke.env import Environment
+from invoke.exceptions import UnknownFileType, UnpicklableConfigMember
+from invoke.runners import Local
+from invoke.terminals import WINDOWS
+from invoke.util import debug, six, yaml
 
 
 if six.PY3:

--- a/invoke/context.py
+++ b/invoke/context.py
@@ -8,10 +8,10 @@ try:
 except ImportError:
     from six import raise_from, iteritems, string_types
 
-from .config import Config, DataProxy
-from .exceptions import Failure, AuthFailure, ResponseNotAccepted
-from .runners import Result
-from .watchers import FailingResponder
+from invoke.config import Config, DataProxy
+from invoke.exceptions import Failure, AuthFailure, ResponseNotAccepted
+from invoke.runners import Result
+from invoke.watchers import FailingResponder
 
 
 class Context(DataProxy):

--- a/invoke/env.py
+++ b/invoke/env.py
@@ -10,10 +10,10 @@ not be included in the Sphinx API documentation.
 
 import os
 
-from .util import six
+from invoke.util import six
 
-from .exceptions import UncastableEnvVar, AmbiguousEnvVar
-from .util import debug
+from invoke.exceptions import UncastableEnvVar, AmbiguousEnvVar
+from invoke.util import debug
 
 
 class Environment(object):

--- a/invoke/exceptions.py
+++ b/invoke/exceptions.py
@@ -9,7 +9,7 @@ condition in a way easily told apart from other, truly unexpected errors".
 from traceback import format_exception
 from pprint import pformat
 
-from .util import six
+from invoke.util import six
 
 
 class CollectionNotFound(Exception):

--- a/invoke/executor.py
+++ b/invoke/executor.py
@@ -1,9 +1,9 @@
-from .util import six
+from invoke.util import six
 
-from .config import Config
-from .parser import ParserContext
-from .util import debug
-from .tasks import Call, Task
+from invoke.config import Config
+from invoke.parser import ParserContext
+from invoke.util import debug
+from invoke.tasks import Call, Task
 
 
 class Executor(object):

--- a/invoke/loader.py
+++ b/invoke/loader.py
@@ -2,9 +2,9 @@ import os
 import sys
 import imp
 
-from . import Config
-from .exceptions import CollectionNotFound
-from .util import debug
+from invoke import Config
+from invoke.exceptions import CollectionNotFound
+from invoke.util import debug
 
 
 class Loader(object):

--- a/invoke/main.py
+++ b/invoke/main.py
@@ -4,7 +4,7 @@ Invoke's own 'binary' entrypoint.
 Dogfoods the `program` module.
 """
 
-from . import __version__, Program
+from inoke import __version__, Program
 
 program = Program(
     name="Invoke",

--- a/invoke/parser/__init__.py
+++ b/invoke/parser/__init__.py
@@ -1,5 +1,9 @@
 # flake8: noqa
-from .parser import *
-from .context import ParserContext
-from .context import ParserContext as Context, to_flag, translate_underscores
-from .argument import Argument
+from invoke.parser.parser import *
+from invoke.parser.context import ParserContext
+from invoke.parser.context import (
+    ParserContext as Context,
+    to_flag,
+    translate_underscores
+)
+from invoke.parser.argument import Argument

--- a/invoke/parser/context.py
+++ b/invoke/parser/context.py
@@ -1,11 +1,11 @@
 import itertools
 
 try:
-    from ..vendor.lexicon import Lexicon
+    from invoke.vendor.lexicon import Lexicon
 except ImportError:
     from lexicon import Lexicon
 
-from .argument import Argument
+from invoke.parser.argument import Argument
 
 
 def translate_underscores(name):

--- a/invoke/parser/parser.py
+++ b/invoke/parser/parser.py
@@ -1,14 +1,14 @@
 import copy
 
 try:
-    from ..vendor.lexicon import Lexicon
-    from ..vendor.fluidity import StateMachine, state, transition
+    from invoke.vendor.lexicon import Lexicon
+    from invoke.vendor.fluidity import StateMachine, state, transition
 except ImportError:
     from lexicon import Lexicon
     from fluidity import StateMachine, state, transition
 
-from ..util import debug
-from ..exceptions import ParseError
+from invoke.util import debug
+from invoke.exceptions import ParseError
 
 
 def is_flag(value):

--- a/invoke/program.py
+++ b/invoke/program.py
@@ -8,14 +8,14 @@ import sys
 import textwrap
 from importlib import import_module  # buffalo buffalo
 
-from .util import six
+from invoke.util import six
 
-from . import Collection, Config, Executor, FilesystemLoader
-from .completion.complete import complete, print_completion_script
-from .parser import Parser, ParserContext, Argument
-from .exceptions import UnexpectedExit, CollectionNotFound, ParseError, Exit
-from .terminals import pty_size
-from .util import debug, enable_logging, helpline
+from invoke import Collection, Config, Executor, FilesystemLoader
+from invoke.completion.complete import complete, print_completion_script
+from invoke.parser import Parser, ParserContext, Argument
+from invoke.exceptions import UnexpectedExit, CollectionNotFound, ParseError, Exit
+from invoke.terminals import pty_size
+from invoke.util import debug, enable_logging, helpline
 
 
 class Program(object):

--- a/invoke/runners.py
+++ b/invoke/runners.py
@@ -9,7 +9,7 @@ import threading
 import time
 import signal
 
-from .util import six
+from invoke.util import six
 
 # Import some platform-specific things at top level so they can be mocked for
 # tests.
@@ -26,7 +26,7 @@ try:
 except ImportError:
     termios = None
 
-from .exceptions import (
+from inoke.exceptions import (
     UnexpectedExit,
     Failure,
     ThreadException,
@@ -34,14 +34,14 @@ from .exceptions import (
     SubprocessPipeError,
     CommandTimedOut,
 )
-from .terminals import (
+from invoke.terminals import (
     WINDOWS,
     pty_size,
     character_buffered,
     ready_for_reading,
     bytes_to_read,
 )
-from .util import has_fileno, isatty, ExceptionHandlingThread, encode_output
+from invoke.util import has_fileno, isatty, ExceptionHandlingThread, encode_output
 
 
 class Runner(object):

--- a/invoke/tasks.py
+++ b/invoke/tasks.py
@@ -7,9 +7,9 @@ from copy import deepcopy
 import inspect
 import types
 
-from .context import Context
-from .parser import Argument, translate_underscores
-from .util import six
+from invoke.context import Context
+from invoke.parser import Argument, translate_underscores
+from invoke.util import six
 
 if six.PY3:
     from itertools import zip_longest

--- a/invoke/terminals.py
+++ b/invoke/terminals.py
@@ -13,7 +13,7 @@ import select
 import sys
 
 # TODO: move in here? They're currently platform-agnostic...
-from .util import has_fileno, isatty
+from invoke.util import has_fileno, isatty
 
 
 WINDOWS = sys.platform == "win32"

--- a/invoke/util.py
+++ b/invoke/util.py
@@ -19,14 +19,14 @@ import sys
 # to worry about it (they can't rely on the imported 'six' directly via
 # attribute access, since six.moves does import shenanigans.)
 try:
-    from .vendor.lexicon import Lexicon  # noqa
-    from .vendor import six
-    from .vendor.six.moves import reduce  # noqa
+    from inoke.vendor.lexicon import Lexicon  # noqa
+    from inoke.vendor import six
+    from inoke.vendor.six.moves import reduce  # noqa
 
     if six.PY3:
-        from .vendor import yaml3 as yaml  # noqa
+        from invoke.vendor import yaml3 as yaml  # noqa
     else:
-        from .vendor import yaml2 as yaml  # noqa
+        from invoke.vendor import yaml2 as yaml  # noqa
 except ImportError:
     from lexicon import Lexicon  # noqa
     import six

--- a/invoke/watchers.py
+++ b/invoke/watchers.py
@@ -1,7 +1,7 @@
 import re
 import threading
 
-from .exceptions import ResponseNotAccepted
+from invoke.exceptions import ResponseNotAccepted
 
 
 class StreamWatcher(threading.local):


### PR DESCRIPTION
This PR is intended to help improve the security of applications using invoke by using explicit paths.

Relative paths can potentially be exploited my malicious libraries. This coupled with the potential use of `sudo` capabilities can allow for privilege escalation.

This is due to the module cache being world writable within CPython.