### PR TITLE
Relax parser context check for true boolean default args from 'is True'.

### DIFF
--- a/invoke/parser/context.py
+++ b/invoke/parser/context.py
@@ -141,7 +141,7 @@ class ParserContext(object):
         if arg.attr_name:
             self.args.alias(arg.attr_name, to=main)
         # Add to inverse_flags if required
-        if arg.kind == bool and arg.default is True:
+        if arg.kind == bool and arg.default:
             # Invert the 'main' flag name here, which will be a dashed version
             # of the primary argument name if underscore-to-dash transformation
             # occurred.


### PR DESCRIPTION
By testing "truthiness" instead of object identity this opens the door for
default value extensions/flexibility and is backwards-compatible (closes #811).