### PR TITLE
Preserve environment variables explicitly passed to Context.sudo.

### DIFF
--- a/invoke/context.py
+++ b/invoke/context.py
@@ -178,6 +178,7 @@ class Context(DataProxy):
         prompt = self.config.sudo.prompt
         password = kwargs.pop("password", self.config.sudo.password)
         user = kwargs.pop("user", self.config.sudo.user)
+        env = kwargs.get("env", {})
         # TODO: allow subclassing for 'get the password' so users who REALLY
         # want lazy runtime prompting can have it easily implemented.
         # TODO: want to print a "cleaner" echo with just 'sudo <command>'; but
@@ -193,8 +194,13 @@ class Context(DataProxy):
         user_flags = ""
         if user is not None:
             user_flags = "-H -u {} ".format(user)
+        env_flags = ""
+        if env:
+            env_flags = "--preserve-env='{}' ".format(",".join(env.keys()))
         command = self._prefix_commands(command)
-        cmd_str = "sudo -S -p '{}' {}{}".format(prompt, user_flags, command)
+        cmd_str = "sudo -S -p '{}' {}{}{}".format(
+            prompt, env_flags, user_flags, command
+        )
         watcher = FailingResponder(
             pattern=re.escape(prompt),
             response="{}\n".format(password),

--- a/tests/context.py
+++ b/tests/context.py
@@ -355,6 +355,17 @@ class Context_:
             # NOTE: possibly best to tie into issue #2
             skip()
 
+        @patch(local_path)
+        def explicit_env_vars_are_preserved(self, Local):
+            runner = Local.return_value
+            Context().sudo(
+                "whoami", env={"GRATUITOUS_ENVIRONMENT_VARIABLE": "arbitrary value"}
+            )
+            assert (
+                "--preserve-env='GRATUITOUS_ENVIRONMENT_VARIABLE'"
+                in runner.run.call_args[0][0]
+            )
+
         def _expect_responses(self, expected, config=None, kwargs=None):
             """
             Execute mocked sudo(), expecting watchers= kwarg in its run().


### PR DESCRIPTION
sudo, by default, will not pass environment variables from the context in which it is invoked to the context in creates to run actual commands in. This is almost certainly the correct thing to do but unfortunately also means that any environment variables that are explicitly passed via the env= kwarg also get removed.

This change adds a --preserve-env= argument to the internal sudo invocation that will ensure that arguments passed via the env= kwarg are presented to the interior command while still ensuring that the rest of the outer environment stays outside.