### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     author_email="jeff@bitprophet.org",
     url="http://docs.pyinvoke.org",
     project_urls={
-        "Source:" "https://github.com/pyinvoke/invoke",
+        "Source": "https://github.com/pyinvoke/invoke",
     },
     packages=find_packages(exclude=exclude),
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,9 @@ setup(
     author="Jeff Forcier",
     author_email="jeff@bitprophet.org",
     url="http://docs.pyinvoke.org",
+    project_urls={
+        "Source:" "https://github.com/pyinvoke/invoke",
+    },
     packages=find_packages(exclude=exclude),
     include_package_data=True,
     entry_points={


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help automation tool find the source code for Requests.

Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)