### PR TITLE
Update invoking-tasks.rst

### DIFF
--- a/sites/docs/concepts/invoking-tasks.rst
+++ b/sites/docs/concepts/invoking-tasks.rst
@@ -537,6 +537,7 @@ doesn't make a ton of real-world sense, let's imagine we wanted to apply
     $ inv --no-dedupe build package
     Cleaning
     Building
+    Cleaning
     Building
     Packaging
 


### PR DESCRIPTION
Original output made it seem like the build task was being run again, but the pre-task of that (clean) was still being deduplicated. Running the example, in line with expectation, shows that the clean task is correctly also repeated if the --no-dedupe flag is set. This is purely a documentation fix.