### PR TITLE
CI: Test on Python 3.10 and 3.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ workflows:
           requires: ["Test"]
           matrix:
             parameters:
-              version: ["3.7", "3.8", "3.9"]
+              version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
       - orb/docs:
           name: "Docs"
           requires: ["Test"]


### PR DESCRIPTION
This PR adds Python 3.10 and 3.11 to the testing matrix of Circle CI.