### PR TITLE
Fix nested merge in _task_with_merged_config

### DIFF
--- a/invoke/collection.py
+++ b/invoke/collection.py
@@ -363,7 +363,7 @@ class Collection(object):
 
     def _task_with_merged_config(self, coll, rest, ours):
         task, config = self.collections[coll].task_with_config(rest)
-        return task, dict(config, **ours)
+        return task, merge_dicts(config, ours)
 
     def task_with_config(self, name):
         """

--- a/tests/collection.py
+++ b/tests/collection.py
@@ -651,14 +651,20 @@ class Collection_:
 
         def access_merges_from_subcollections(self):
             inner = Collection("inner", self.task)
-            inner.configure({"foo": "bar"})
-            self.root.configure({"biz": "baz"})
+            inner.configure({"foo": "bar", "biz": {"foo": "one"}})
+            self.root.configure({"biz": {"bar": "two"}})
             # With no inner collection
             assert set(self.root.configuration().keys()) == {"biz"}
             # With inner collection
             self.root.add_collection(inner)
-            keys = set(self.root.configuration("inner.task").keys())
+            task_config = self.root.configuration("inner.task")
+            keys = set(task_config.keys())
             assert keys == {"foo", "biz"}
+            biz_keys = set(task_config["biz"].keys())
+            assert biz_keys == {"foo", "bar"}
+            assert task_config["foo"] == "bar"
+            assert task_config["biz"]["foo"] == "one"
+            assert task_config["biz"]["bar"] == "two"
 
         def parents_overwrite_children_in_path(self):
             inner = Collection("inner", self.task)


### PR DESCRIPTION
Currently, `_task_with_merged_config` returns a single level merged
dict.
Howerver, if the config contains nested dicts, only the first
level gets merged, removing eventual fields non defined
in origin config.

This aims to recursively merge config when retrieving the task config,
and to unify how collection configs are merged.