### PR TITLE
Drop mock requirement on Python > 3.3

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -15,7 +15,7 @@ alabaster==0.7.12
 pytest==4.6.3
 pytest-relaxed==1.1.5
 pytest-cov==2.5.1
-mock==1.0.1
+mock==1.0.1; python_version < '3.3'
 # Formatting
 flake8==3.7.8
 black==18.6b4

--- a/integration/runners.py
+++ b/integration/runners.py
@@ -2,7 +2,11 @@ import os
 import platform
 import time
 
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
+
 from pytest import skip, raises
 
 from invoke import (

--- a/tests/_support/custom_executor.py
+++ b/tests/_support/custom_executor.py
@@ -1,4 +1,7 @@
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 
 CustomExecutor = Mock()

--- a/tests/_util.py
+++ b/tests/_util.py
@@ -10,7 +10,11 @@ from contextlib import contextmanager
 
 from invoke.vendor.six import BytesIO, b, wraps
 
-from mock import patch, Mock
+try:
+    from unittest.mock import patch, Mock
+except ImportError:
+    from mock import patch, Mock
+
 from pytest import skip
 from pytest_relaxed import trap
 

--- a/tests/config.py
+++ b/tests/config.py
@@ -3,7 +3,12 @@ import os
 from os.path import join
 
 from invoke.util import six
-from mock import patch, call, Mock
+
+try:
+    from unittest.mock import patch, call, Mock
+except ImportError:
+    from mock import patch, call, Mock
+
 import pytest
 from pytest_relaxed import raises
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,11 @@ import termios
 
 from invoke.vendor.six import iteritems
 import pytest
-from mock import patch
+
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 from _util import support
 

--- a/tests/context.py
+++ b/tests/context.py
@@ -3,7 +3,11 @@ import pickle
 import re
 import sys
 
-from mock import patch, Mock, call
+try:
+    from unittest.mock import patch, Mock, call
+except ImportError:
+    from mock import patch, Mock, call
+
 from pytest_relaxed import trap
 from pytest import skip, raises, mark
 

--- a/tests/executor.py
+++ b/tests/executor.py
@@ -1,4 +1,7 @@
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 import pytest
 
 from invoke import Collection, Config, Context, Executor, Task, call, task

--- a/tests/init.py
+++ b/tests/init.py
@@ -2,7 +2,10 @@ import re
 
 import six
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 import invoke
 import invoke.collection

--- a/tests/program.py
+++ b/tests/program.py
@@ -3,7 +3,12 @@ import os
 import sys
 
 from invoke.util import six, Lexicon
-from mock import patch, Mock, ANY
+
+try:
+    from unittest.mock import patch, Mock, ANY
+except ImportError:
+    from mock import patch, Mock, ANY
+
 import pytest
 from pytest import skip
 from pytest_relaxed import trap

--- a/tests/runners.py
+++ b/tests/runners.py
@@ -14,7 +14,11 @@ from invoke.vendor.six import StringIO, b, PY2, iteritems
 
 from pytest import raises, skip
 from pytest_relaxed import trap
-from mock import patch, Mock, call
+
+try:
+    from unittest.mock import patch, Mock, call
+except ImportError:
+    from mock import patch, Mock, call
 
 from invoke import (
     CommandTimedOut,

--- a/tests/task.py
+++ b/tests/task.py
@@ -1,4 +1,7 @@
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 from pytest import raises, skip
 
 from invoke import Context, Config, task, Task, Call, Collection

--- a/tests/terminals.py
+++ b/tests/terminals.py
@@ -1,7 +1,11 @@
 import fcntl
 import termios
 
-from mock import Mock, patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
+
 from pytest import skip, mark
 
 from invoke.terminals import pty_size, bytes_to_read, WINDOWS


### PR DESCRIPTION
Since Python 3.3 mock is also provided by `unittest.mock` which is a buildin preferred over the standalone module.