### PR TITLE
tests: refactor to resolve deprecated pytest features

### DIFF
--- a/tests/cli.py
+++ b/tests/cli.py
@@ -8,7 +8,7 @@ class CLIParsing:
     High level parsing tests
     """
 
-    def setup(self):
+    def setup_method(self):
         @task(positional=[], iterable=["my_list"], incrementable=["verbose"])
         def my_task(
             c,

--- a/tests/collection.py
+++ b/tests/collection.py
@@ -102,7 +102,7 @@ class Collection_:
             submeh = Collection("submeh", task3)
             return Collection("meh", task1, task2, submeh)
 
-        def setup(self):
+        def setup_method(self):
             self.c = self._meh()
 
         def repr_(self):
@@ -148,11 +148,11 @@ class Collection_:
             assert not Collection(foo=Collection())
 
     class from_module:
-        def setup(self):
+        def setup_method(self):
             self.c = Collection.from_module(load("integration"))
 
         class parameters:
-            def setup(self):
+            def setup_method(self):
                 self.mod = load("integration")
                 self.from_module = Collection.from_module
 
@@ -232,7 +232,7 @@ class Collection_:
             assert c3 is not c4
 
         class explicit_root_ns:
-            def setup(self):
+            def setup_method(self):
                 mod = load("explicit_root")
                 mod.ns.configure(
                     {
@@ -278,7 +278,7 @@ class Collection_:
                 assert self.changed.__doc__.strip() == expected
 
     class add_task:
-        def setup(self):
+        def setup_method(self):
             self.c = Collection()
 
         def associates_given_callable_with_given_name(self):
@@ -350,7 +350,7 @@ class Collection_:
                 assert self.c[x] is self.c["biz"]
 
     class add_collection:
-        def setup(self):
+        def setup_method(self):
             self.c = Collection()
 
         def adds_collection_as_subcollection_of_self(self):
@@ -394,7 +394,7 @@ class Collection_:
     class getitem:
         "__getitem__"
 
-        def setup(self):
+        def setup_method(self):
             self.c = Collection()
 
         def finds_own_tasks_by_name(self):
@@ -447,7 +447,7 @@ class Collection_:
                 self.c["whatever"]
 
     class to_contexts:
-        def setup(self):
+        def setup_method(self):
             @task
             def mytask(c, text, boolean=False, number=5):
                 print(text)
@@ -598,7 +598,7 @@ class Collection_:
             assert "mytask27" in self.aliases
 
     class task_names:
-        def setup(self):
+        def setup_method(self):
             self.c = Collection.from_module(load("explicit_root"))
 
         def returns_all_task_names_including_subtasks(self):
@@ -614,7 +614,7 @@ class Collection_:
     class configuration:
         "Configuration methods"
 
-        def setup(self):
+        def setup_method(self):
             self.root = Collection()
             self.task = Task(_func, name="task")
 

--- a/tests/completion.py
+++ b/tests/completion.py
@@ -32,13 +32,13 @@ class CompletionScriptPrinter:
     Printing the completion script
     """
 
-    def setup(self):
+    def setup_method(self):
         self.prev_cwd = os.getcwd()
         # Chdir to system root to (hopefully) avoid any tasks.py. This will
         # prove that --print-completion-script works w/o nearby tasks.
         os.chdir(ROOT)
 
-    def teardown(self):
+    def teardown_method(self):
         os.chdir(self.prev_cwd)
 
     def only_accepts_certain_shells(self):

--- a/tests/concurrency.py
+++ b/tests/concurrency.py
@@ -6,7 +6,7 @@ from invoke.util import ExceptionWrapper, ExceptionHandlingThread as EHThread
 # TODO: rename
 class ExceptionHandlingThread_:
     class via_target:
-        def setup(self):
+        def setup_method(self):
             def worker(q):
                 q.put(7)
 
@@ -48,7 +48,7 @@ class ExceptionHandlingThread_:
             assert not t.is_dead
 
     class via_subclassing:
-        def setup(self):
+        def setup_method(self):
             class MyThread(EHThread):
                 def __init__(self, *args, **kwargs):
                     self.queue = kwargs.pop("queue")

--- a/tests/context.py
+++ b/tests/context.py
@@ -63,7 +63,7 @@ class Context_:
     class configuration_proxy:
         "Dict-like proxy for self.config"
 
-        def setup(self):
+        def setup_method(self):
             config = Config(defaults={"foo": "bar", "biz": {"baz": "boz"}})
             self.c = Context(config=config)
 
@@ -133,7 +133,7 @@ class Context_:
             assert self.c.biz.otherbaz == "otherboz"
 
     class cwd:
-        def setup(self):
+        def setup_method(self):
             self.c = Context()
 
         def simple(self):
@@ -401,7 +401,7 @@ class Context_:
             self._expect_responses(expected, config=config, kwargs=kwargs)
 
         class auto_response_merges_with_other_responses:
-            def setup(self):
+            def setup_method(self):
                 class DummyWatcher(StreamWatcher):
                     def submit(self, stream):
                         pass

--- a/tests/executor.py
+++ b/tests/executor.py
@@ -13,7 +13,7 @@ pytestmark = pytest.mark.usefixtures("integration")
 
 
 class Executor_:
-    def setup(self):
+    def setup_method(self):
         self.task1 = Task(Mock(return_value=7))
         self.task2 = Task(Mock(return_value=10), pre=[self.task1])
         self.task3 = Task(Mock(), pre=[self.task1])

--- a/tests/loader.py
+++ b/tests/loader.py
@@ -79,7 +79,7 @@ class Loader_:
 
 
 class FilesystemLoader_:
-    def setup(self):
+    def setup_method(self):
         self.loader = FSLoader(start=support)
 
     def discovery_start_point_defaults_to_cwd(self):

--- a/tests/parser_context.py
+++ b/tests/parser_context.py
@@ -28,7 +28,7 @@ class Context_:
     # tests within 'add_arg'.  Some of this behavior is technically driven by
     # add_arg.
     class args:
-        def setup(self):
+        def setup_method(self):
             self.c = Context(
                 args=(
                     Argument("foo"),
@@ -56,7 +56,7 @@ class Context_:
             assert "wat" not in self.c.flags
 
     class add_arg:
-        def setup(self):
+        def setup_method(self):
             self.c = Context()
 
         def can_take_Argument_instance(self):
@@ -134,7 +134,7 @@ class Context_:
     class deepcopy:
         "__deepcopy__"
 
-        def setup(self):
+        def setup_method(self):
             self.arg = Argument("--boolean")
             self.orig = Context(
                 name="mytask", args=(self.arg,), aliases=("othername",)
@@ -157,7 +157,7 @@ class Context_:
             assert not self.arg.value
 
     class help_for:
-        def setup(self):
+        def setup_method(self):
             # Normal, non-task/collection related Context
             self.vanilla = Context(
                 args=(Argument("foo"), Argument("bar", help="bar the baz"))

--- a/tests/parser_parser.py
+++ b/tests/parser_parser.py
@@ -168,7 +168,7 @@ class Parser_:
             assert a2.value == "val"
 
         class parsing_errors:
-            def setup(self):
+            def setup_method(self):
                 self.p = Parser([Context(name="foo", args=[Argument("bar")])])
 
             def missing_flag_values_raise_ParseError(self):
@@ -280,7 +280,7 @@ class Parser_:
             assert a.bar.value is True
 
     class optional_arg_values:
-        def setup(self):
+        def setup_method(self):
             self.parser = self._parser()
 
         def _parser(self, arguments=None):
@@ -525,7 +525,7 @@ class Parser_:
 class ParseResult_:
     "ParseResult"
 
-    def setup(self):
+    def setup_method(self):
         self.context = Context(
             "mytask", args=(Argument("foo", kind=str), Argument("bar"))
         )

--- a/tests/program.py
+++ b/tests/program.py
@@ -1193,7 +1193,7 @@ Default 'build' task: .all
                     )
 
             class json:
-                def setup(self):
+                def setup_method(self):
                     # Stored expected data as an actual JSON file cuz it's big
                     # & looks like crap if inlined. Plus by round-tripping it
                     # we remove the pretty-printing. Win-win?

--- a/tests/runners.py
+++ b/tests/runners.py
@@ -84,7 +84,7 @@ def _expect_platform_shell(shell):
         assert shell == "/bin/bash"
 
 
-def make_tcattrs(cc_is_ints=True, echo=False):
+def _make_tcattrs(cc_is_ints=True, echo=False):
     # Set up the control character sub-array; it's technically platform
     # dependent so we need to be dynamic.
     # NOTE: setting this up so we can test both potential values for
@@ -665,7 +665,7 @@ class Runner_:
                     assert repr(e) == expected.format(_)
 
         class UnexpectedExit_str:
-            def setup(self):
+            def setup_method(self):
                 def lines(prefix):
                     prefixed = "\n".join(
                         "{} {}".format(prefix, x) for x in range(1, 26)
@@ -1238,7 +1238,7 @@ stderr 25
         @skip_if_windows
         @patch("invoke.terminals.tty")
         def setcbreak_called_on_tty_stdins(self, mock_tty, mock_termios):
-            mock_termios.tcgetattr.return_value = make_tcattrs(echo=True)
+            mock_termios.tcgetattr.return_value = _make_tcattrs(echo=True)
             self._run(_)
             mock_tty.setcbreak.assert_called_with(sys.stdin)
 
@@ -1269,7 +1269,7 @@ stderr 25
         ):
             # Get already-cbroken attrs since that's an easy way to get the
             # right format/layout
-            attrs = make_tcattrs(echo=True)
+            attrs = _make_tcattrs(echo=True)
             mock_termios.tcgetattr.return_value = attrs
             self._run(_)
             # Ensure those old settings are being restored
@@ -1283,7 +1283,7 @@ stderr 25
             self, mock_tty, mock_termios
         ):
             # This test is re: GH issue #303
-            sentinel = make_tcattrs(echo=True)
+            sentinel = _make_tcattrs(echo=True)
             mock_termios.tcgetattr.return_value = sentinel
             # Don't actually bubble up the KeyboardInterrupt...
             try:
@@ -1307,7 +1307,7 @@ stderr 25
             # Test both bytes and ints versions of CC values, since docs
             # disagree with at least some platforms' realities on that.
             for is_ints in (True, False):
-                mock_termios.tcgetattr.return_value = make_tcattrs(
+                mock_termios.tcgetattr.return_value = _make_tcattrs(
                     cc_is_ints=is_ints
                 )
                 self._run(_)
@@ -1752,7 +1752,7 @@ class Result_:
         assert repr(Result(command="foo")) == "<Result cmd='foo' exited=0>"
 
     class tail:
-        def setup(self):
+        def setup_method(self):
             self.sample = "\n".join(str(x) for x in range(25))
 
         def returns_last_10_lines_of_given_stream_plus_whitespace(self):

--- a/tests/task.py
+++ b/tests/task.py
@@ -25,7 +25,7 @@ class task_:
         mod, _ = self.loader.load(name)
         return Collection.from_module(mod)
 
-    def setup(self):
+    def setup_method(self):
         self.loader = Loader(start=support)
         self.vanilla = self._load("decorators")
 
@@ -215,7 +215,7 @@ class Task_:
             assert Task(_func, name="foo").name == "foo"
 
     class callability:
-        def setup(self):
+        def setup_method(self):
             @task
             def foo(c):
                 "My docstring"
@@ -258,7 +258,7 @@ class Task_:
             assert self.task.__name__ == "foo"
 
     class get_arguments:
-        def setup(self):
+        def setup_method(self):
             @task(positional=["arg_3", "arg1"], optional=["arg1"])
             def mytask(c, arg1, arg2=False, arg_3=5):
                 pass
@@ -378,7 +378,7 @@ class Task_:
             assert arg.name == "longer_arg"
 
         class help:
-            def setup(self):
+            def setup_method(self):
                 @task(
                     help={
                         "simple": "key",
@@ -450,7 +450,7 @@ _ = object()
 
 
 class Call_:
-    def setup(self):
+    def setup_method(self):
         self.task = Task(Mock(__name__="mytask"))
 
     class init:


### PR DESCRIPTION
Just following the pytest recommendations here. The tests still function correctly without all the false warnings.

https://github.com/pyinvoke/invoke/issues/901