### PR TITLE
Remove python version from README text

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@
 Welcome to Invoke!
 ==================
 
-Invoke is a Python (2.7 and 3.4+) library for managing shell-oriented
+Invoke is a Python library for managing shell-oriented
 subprocesses and organizing executable Python code into CLI-invokable tasks. It
 draws inspiration from various sources (``make``/``rake``, Fabric 1.x, etc) to
 arrive at a powerful & clean feature set.


### PR DESCRIPTION
Version numbers are handled by shields. 
Duplicating it in the body just leads to it going stale.