### PR TITLE
Fix `Context.cd()` behavior to match the type hint

### DIFF
--- a/invoke/context.py
+++ b/invoke/context.py
@@ -389,7 +389,7 @@ class Context(DataProxy):
             (such as the various ``Path`` objects out there), and not just
             string literals.
         """
-        path = str(path)
+        path = os.fspath(path)
         self.command_cwds.append(path)
         try:
             yield


### PR DESCRIPTION
Issue found when fixing the type hint in typeshed: https://github.com/python/typeshed/pull/9823#pullrequestreview-1316129640
