### PR TITLE
Add pre and post task lists into help output

### DIFF
--- a/invoke/program.py
+++ b/invoke/program.py
@@ -781,6 +781,8 @@ class Program:
         ctx = self.parser.contexts[name]
         tuples = ctx.help_tuples()
         docstring = inspect.getdoc(self.collection[name])
+        pre_tasks = self.collection[name].pre
+        post_tasks = self.collection[name].post
         header = "Usage: {} [--core-opts] {} {}[other tasks here ...]"
         opts = "[--options] " if tuples else ""
         print(header.format(self.binary, name, opts))
@@ -800,6 +802,27 @@ class Program:
         print("Options:")
         if tuples:
             self.print_columns(tuples)
+        else:
+            print(self.leading_indent + "none")
+            print("")
+
+        print("Pre-tasks:")
+        if pre_tasks:
+            for pre in pre_tasks:
+                print(
+                    self.leading_indent + self.collection.transform(pre.name)
+                )
+            print("")
+        else:
+            print(self.leading_indent + "none")
+            print("")
+        print("Post-tasks:")
+        if post_tasks:
+            for post in post_tasks:
+                print(
+                    self.leading_indent + self.collection.transform(post.name)
+                )
+            print("")
         else:
             print(self.leading_indent + "none")
             print("")

--- a/tests/_support/decorators.py
+++ b/tests/_support/decorators.py
@@ -21,7 +21,7 @@ def foo2(c):
     pass
 
 
-@task
+@task(post=[foo2])
 def foo3(c):
     """Foo the other bar:
 
@@ -32,7 +32,7 @@ def foo3(c):
     pass
 
 
-@task(default=True)
+@task(default=True, pre=[foo3])
 def biz(c):
     pass
 

--- a/tests/program.py
+++ b/tests/program.py
@@ -308,6 +308,7 @@ class Program_:
             # .value = <default value> actually ends up creating a
             # list-of-lists.
             p = Program()
+
             # Set up core-args parser context with an iterable arg that hasn't
             # seen any value yet
             def filename_args():
@@ -643,6 +644,12 @@ Options:
   -h STRING, --why=STRING   Motive
   -w STRING, --who=STRING   Who to punch
 
+Pre-tasks:
+  none
+
+Post-tasks:
+  none
+
 """.lstrip()
                 for flag in ["-h", "--help"]:
                     expect("-c decorators {} punch".format(flag), out=expected)
@@ -655,6 +662,12 @@ Docstring:
   none
 
 Options:
+  none
+
+Pre-tasks:
+  foo3
+
+Post-tasks:
   none
 
 """.lstrip()
@@ -676,6 +689,12 @@ Docstring:
 Options:
   none
 
+Pre-tasks:
+  none
+
+Post-tasks:
+  none
+
 """.lstrip()
                 expect("-c decorators -h foo", out=expected)
 
@@ -691,6 +710,12 @@ Docstring:
   Added in 1.0
 
 Options:
+  none
+
+Pre-tasks:
+  none
+
+Post-tasks:
   none
 
 """.lstrip()
@@ -710,6 +735,12 @@ Docstring:
 Options:
   none
 
+Pre-tasks:
+  none
+
+Post-tasks:
+  foo2
+
 """.lstrip()
                 expect("-c decorators -h foo3", out=expected)
 
@@ -725,6 +756,12 @@ Docstring:
 Options:
   -h STRING, --why=STRING   Motive
   -w STRING, --who=STRING   Who to punch
+
+Pre-tasks:
+  none
+
+Post-tasks:
+  none
 
 """.lstrip()
                 expect("-c decorators -h punch --list", out=expected)
@@ -1374,6 +1411,7 @@ post2
 
         def env_var_prefix_can_be_overridden(self, monkeypatch):
             monkeypatch.setenv("MYAPP_RUN_HIDE", "both")
+
             # This forces the execution stuff, including Executor, to run
             # NOTE: it's not really possible to rework the impl so this test is
             # cleaner - tasks require per-task/per-collection config, which can


### PR DESCRIPTION
Example output

```bash
❯ inv --help main-task
Usage: inv[oke] [--core-opts] main-task [other tasks here ...]

Docstring:
  none

Options:
  none

Pre-tasks:
  pre-task
  pre-task-2

Post-tasks:
  none

```

Issue: #860