### PR TITLE
fix: resolve config regression with new loader capability

### DIFF
--- a/invoke/parser/context.py
+++ b/invoke/parser/context.py
@@ -91,7 +91,7 @@ class ParserContext:
         self.args = Lexicon()
         self.positional_args: List[Argument] = []
         self.flags = Lexicon()
-        self.inverse_flags: Dict[str, str] = {}  # No need for Lexicon here
+        self.inverse_flags: Dict[str, Any] = {}  # No need for Lexicon here
         self.name = name
         self.aliases = aliases
         for arg in args:

--- a/invoke/program.py
+++ b/invoke/program.py
@@ -718,7 +718,7 @@ class Program:
             # allows project config to affect the task parsing step!
             # TODO: is it worth merging these set- and load- methods? May
             # require more tweaking of how things behave in/after __init__.
-            self.config.set_project_location(parent)
+            self.config.set_project_location(os.getcwd())
             self.config.load_project()
             self.collection = Collection.from_module(
                 module,


### PR DESCRIPTION
@bitprophet Seems there is an idiosyncrasy with how the new loader provides the parent path. I switched it to `cwd` but I'm sure there are some additional details here.

Issue is here: https://github.com/pyinvoke/invoke/issues/944 