### PR TITLE
Add PTY-Support for windows

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -21,3 +21,6 @@ icecream>=2.1
 # typing
 mypy==0.971
 types-PyYAML==6.0.12.4
+# windows pty support
+windows-curses
+pywinpty

--- a/invoke/runners.py
+++ b/invoke/runners.py
@@ -27,6 +27,7 @@ try:
     import pty
     import fcntl
     import termios
+
     UNIX = True
 except ImportError:
     pty = None
@@ -408,9 +409,7 @@ class Runner:
         # Normalize kwargs w/ config; sets self.opts, self.streams
         self._unify_kwargs_with_config(kwargs)
         # Environment setup
-        self.env = self.generate_env(
-            self.opts["env"], self.opts["replace_env"]
-        )
+        self.env = self.generate_env(self.opts["env"], self.opts["replace_env"])
         # Arrive at final encoding if neither config nor kwargs had one
         self.encoding = self.opts["encoding"] or self.default_encoding()
         # Echo running command (wants to be early to be included in dry-run)
@@ -601,9 +600,7 @@ class Runner:
         # TODO: as noted elsewhere, I kinda hate this. Consider changing
         # generate_result()'s API in next major rev so we can tidy up.
         result = self.generate_result(
-            **dict(
-                self.result_kwargs, stdout=stdout, stderr=stderr, exited=exited
-            )
+            **dict(self.result_kwargs, stdout=stdout, stderr=stderr, exited=exited)
         )
         return result
 
@@ -754,9 +751,7 @@ class Runner:
             # Run our specific buffer through the autoresponder framework
             self.respond(buffer_)
 
-    def handle_stdout(
-        self, buffer_: List[str], hide: bool, output: IO
-    ) -> None:
+    def handle_stdout(self, buffer_: List[str], hide: bool, output: IO) -> None:
         """
         Read process' stdout, storing into a buffer & printing/parsing.
 
@@ -773,13 +768,9 @@ class Runner:
 
         .. versionadded:: 1.0
         """
-        self._handle_output(
-            buffer_, hide, output, reader=self.read_proc_stdout
-        )
+        self._handle_output(buffer_, hide, output, reader=self.read_proc_stdout)
 
-    def handle_stderr(
-        self, buffer_: List[str], hide: bool, output: IO
-    ) -> None:
+    def handle_stderr(self, buffer_: List[str], hide: bool, output: IO) -> None:
         """
         Read process' stderr, storing into a buffer & printing/parsing.
 
@@ -788,9 +779,7 @@ class Runner:
 
         .. versionadded:: 1.0
         """
-        self._handle_output(
-            buffer_, hide, output, reader=self.read_proc_stderr
-        )
+        self._handle_output(buffer_, hide, output, reader=self.read_proc_stderr)
 
     def read_our_stdin(self, input_: IO) -> Optional[str]:
         """
@@ -939,9 +928,7 @@ class Runner:
             for response in watcher.submit(stream):
                 self.write_proc_stdin(response)
 
-    def generate_env(
-        self, env: Dict[str, Any], replace_env: bool
-    ) -> Dict[str, Any]:
+    def generate_env(self, env: Dict[str, Any], replace_env: bool) -> Dict[str, Any]:
         """
         Return a suitable environment dict based on user input & behavior.
 
@@ -1297,9 +1284,7 @@ class Local(Runner):
         elif self.process and self.process.stdin:
             fd = self.process.stdin.fileno()
         else:
-            raise SubprocessPipeError(
-                "Unable to write to missing subprocess or stdin!"
-            )
+            raise SubprocessPipeError("Unable to write to missing subprocess or stdin!")
         # Try to write, ignoring broken pipes if encountered (implies child
         # process exited before the process piping stdin to us finished;
         # there's nothing we can do about that!)
@@ -1317,9 +1302,7 @@ class Local(Runner):
         elif self.process and self.process.stdin:
             self.process.stdin.close()
         else:
-            raise SubprocessPipeError(
-                "Unable to close missing subprocess or stdin!"
-            )
+            raise SubprocessPipeError("Unable to close missing subprocess or stdin!")
 
     def start(self, command: str, shell: str, env: Dict[str, Any]) -> None:
         if self.using_pty:
@@ -1363,7 +1346,6 @@ class Local(Runner):
                 stderr=PIPE,
                 stdin=PIPE,
             )
-
 
     def kill(self) -> None:
         pid = self.pid if self.using_pty else self.process.pid

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import sys
-import termios
 
 import pytest
 from unittest.mock import patch
@@ -10,6 +9,12 @@ from _util import support
 
 # Set up icecream globally for convenience.
 from icecream import install
+
+try:
+    import termios
+except ImportError:
+    termios = None
+    
 
 install()
 
@@ -82,6 +87,8 @@ def integration(reset_environ, chdir_support, clean_sys_modules):
 
 @pytest.fixture
 def mock_termios():
+    if termios is None:
+        pytest.skip("termios not available on this platform")
     with patch("invoke.terminals.termios") as mocked:
         # Ensure mocked termios has 'real' values for constants...otherwise
         # doing bit arithmetic on Mocks kinda defeats the point.


### PR DESCRIPTION
## Summary:
As mentioned in #561, PTY is currently missing support on windows, which somewhat limits `invoke`'s usefulness for windows users.
I quickly threw together a PR to demo the changes necessary, which I present here as a starting of point.

## Changes:
- I added a conditional import to use `pywinpty` on Windows.
- I added requirements for pywinpty and windows-curses to `dev-requirements.txt`
- I've made the changes necessary successfully to run a quick example on widows

## Notes:
- Because I don't have a lot of time, this PR **work in progress** and serves as a **proof of concept**
- Right now it looks like this project doesn't have any other non-dev dependencies.
- In the end, conditionally importing the additional dependencies on windows would be for the best. For example:
```toml
dependencies = [
    "pywinpty; sys_platform == 'win32'",
    "windows-curses; sys_platform == 'win32'",
]
```

## Testing:
- [ ] On windows, I ran a quick test invoke in a different project using pty=true and false to make sure the changes worked as expected
- [ ] I still have to run test's on other platforms, but I will use the CI workflow as a starting of point for that.

> If there is any interest in fixing this, I'd be happy for any help, feedback or changes. I'm strapped for time with other projects as it stands unfortunately, so feel free to help out!