### PR TITLE
Speed up reading from in_stream

### DIFF
--- a/invoke/runners.py
+++ b/invoke/runners.py
@@ -912,8 +912,10 @@ class Runner:
                 # race conditions re: unread stdin.)
                 if self.program_finished.is_set() and not data:
                     break
+                # When data is None, we're waiting for input on stdin.
                 # Take a nap so we're not chewing CPU.
-                time.sleep(self.input_sleep)
+                if data is None:
+                    time.sleep(self.input_sleep)
 
     def should_echo_stdin(self, input_: IO, output: IO) -> bool:
         """

--- a/invoke/runners.py
+++ b/invoke/runners.py
@@ -1,5 +1,6 @@
 import errno
 import locale
+import io
 import os
 import signal
 import struct
@@ -72,7 +73,7 @@ class Runner:
 
     opts: Dict[str, Any]
     using_pty: bool
-    read_chunk_size = 1000
+    read_chunk_size = io.DEFAULT_BUFFER_SIZE
     input_sleep = 0.01
 
     def __init__(self, context: "Context") -> None:

--- a/tests/runners.py
+++ b/tests/runners.py
@@ -7,7 +7,7 @@ import termios
 import threading
 import types
 from contextlib import AbstractContextManager
-from io import BytesIO, StringIO
+from io import BytesIO, StringIO, TextIOBase
 from itertools import chain, repeat
 from unittest.mock import Mock, call, patch
 
@@ -1100,16 +1100,52 @@ stderr 25
             class MyRunner(_Dummy):
                 input_sleep = 0.007
 
+            def fake_stdin_stream():
+                # The value "foo" is eventually returned.
+                yield "f"
+                # None values simulate waiting for input on stdin.
+                yield None
+                yield "o"
+                yield None
+                yield "o"
+                yield None
+                # Once the stream is closed, stdin returns empty strings.
+                while True:
+                    yield ""
+
+            class FakeStdin(TextIOBase):
+                def __init__(self, stdin):
+                    self.stream = stdin
+
+                def read(self, size):
+                    return next(self.stream)
+
             with patch("invoke.runners.time") as mock_time:
                 MyRunner(Context()).run(
                     _,
-                    in_stream=StringIO("foo"),
+                    in_stream=FakeStdin(fake_stdin_stream()),
                     out_stream=StringIO(),  # null output to not pollute tests
                 )
-            # Just make sure the first few sleeps all look good. Can't know
-            # exact length of list due to stdin worker hanging out til end of
-            # process. Still worth testing more than the first tho.
-            assert mock_time.sleep.call_args_list[:3] == [call(0.007)] * 3
+            # Just make sure the sleeps all look good.
+            # There are three calls because of the Nones in fake_stdin_stream.
+            assert mock_time.sleep.call_args_list == [call(0.007)] * 3
+
+        @mock_subprocess()
+        def populated_streams_do_not_sleep(self):
+            class MyRunner(_Dummy):
+                read_chunk_size = 1
+
+            runner = MyRunner(Context())
+            with patch("invoke.runners.time") as mock_time:
+                with patch.object(runner, "wait"):
+                    runner.run(
+                        _,
+                        in_stream=StringIO("lots of bytes to read"),
+                        # null output to not pollute tests
+                        out_stream=StringIO(),
+                    )
+            # Sleep should not be called before we break.
+            assert len(mock_time.sleep.call_args_list) == 0
 
     class stdin_mirroring:
         def _test_mirroring(self, expect_mirroring, **kwargs):


### PR DESCRIPTION
By only sleeping when the input stream is waiting, this change ensures that we don't delay when there is still data available to read.

This provides a significant speed improvement to scripts which are passing a populated stream of data, rather than awaiting user input from stdin.

I had to modify an existing test to ensure that it continued to see `sleep`s.

I have also changed the default chunk read size to match [Python's default](https://docs.python.org/3/library/io.html#io.DEFAULT_BUFFER_SIZE), which is the "[“Preferred” blocksize for efficient file system I/O.](https://docs.python.org/3/library/os.html#os.stat_result.st_blksize)" (Of course, I'm happy to revert this if it makes the PR more palatable.)

Fixes https://github.com/pyinvoke/invoke/issues/774