### PR TITLE
QOL: Context run command accepts either str or list

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,4 +3,6 @@ branch = True
 include =
     invoke/*
     tests/*
-omit = invoke/vendor/*
+omit =
+    invoke/shims.py
+    invoke/vendor/*

--- a/invoke/__init__.py
+++ b/invoke/__init__.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any, List, Optional, Union
 
 from ._version import __version_info__, __version__  # noqa
 from .collection import Collection  # noqa
@@ -31,7 +31,7 @@ from .terminals import pty_size  # noqa
 from .watchers import FailingResponder, Responder, StreamWatcher  # noqa
 
 
-def run(command: str, **kwargs: Any) -> Optional[Result]:
+def run(command: Union[str, List[str]], **kwargs: Any) -> Optional[Result]:
     """
     Run ``command`` in a subprocess and return a `.Result` object.
 
@@ -50,7 +50,7 @@ def run(command: str, **kwargs: Any) -> Optional[Result]:
     return Context().run(command, **kwargs)
 
 
-def sudo(command: str, **kwargs: Any) -> Optional[Result]:
+def sudo(command: Union[str, List[str]], **kwargs: Any) -> Optional[Result]:
     """
     Run ``command`` in a ``sudo`` subprocess and return a `.Result` object.
 

--- a/invoke/context.py
+++ b/invoke/context.py
@@ -1,5 +1,6 @@
 import os
 import re
+import shlex
 from contextlib import contextmanager
 from itertools import cycle
 from os import PathLike
@@ -87,7 +88,7 @@ class Context(DataProxy):
         # runtime.
         self._set(_config=value)
 
-    def run(self, command: str, **kwargs: Any) -> Optional[Result]:
+    def run(self, command: Union[str, List[str]], **kwargs: Any) -> Optional[Result]:
         """
         Execute a local shell command, honoring config options.
 
@@ -101,6 +102,8 @@ class Context(DataProxy):
         .. versionadded:: 1.0
         """
         runner = self.config.runners.local(self)
+        if isinstance(command, list):
+            command = shlex.join(command)
         return self._run(runner, command, **kwargs)
 
     # NOTE: broken out of run() to allow for runner class injection in
@@ -112,7 +115,7 @@ class Context(DataProxy):
         command = self._prefix_commands(command)
         return runner.run(command, **kwargs)
 
-    def sudo(self, command: str, **kwargs: Any) -> Optional[Result]:
+    def sudo(self, command: Union[str, List[str]], **kwargs: Any) -> Optional[Result]:
         """
         Execute a shell command via ``sudo`` with password auto-response.
 
@@ -182,6 +185,8 @@ class Context(DataProxy):
         .. versionadded:: 1.0
         """
         runner = self.config.runners.local(self)
+        if isinstance(command, list):
+            command = shlex.join(command)
         return self._sudo(runner, command, **kwargs)
 
     # NOTE: this is for runner injection; see NOTE above _run().

--- a/invoke/context.py
+++ b/invoke/context.py
@@ -35,7 +35,7 @@ else:
 
     def shlex_join(split_command: List) -> str:
         """Convert command from list to str."""
-        return shlex.quote(" ".join(split_command))
+        return shlex.quote(" ".join(split_command))[1:-1]
 
 
 class Context(DataProxy):

--- a/invoke/context.py
+++ b/invoke/context.py
@@ -25,13 +25,17 @@ if TYPE_CHECKING:
     from invoke.runners import Runner
 
 
-def shlex_join(split_command: List) -> str:
-    """Convert command from list to str."""
-    return (
-        shlex.join(split_command)
-        if sys.version_info >= (3, 8)
-        else shlex.quote(" ".join(split_command))[1:-1]
-    )
+if sys.version_info >= (3, 8):
+
+    def shlex_join(split_command: List) -> str:
+        """Convert command from list to str."""
+        return shlex.join(split_command)
+
+else:
+
+    def shlex_join(split_command: List) -> str:
+        """Convert command from list to str."""
+        return shlex.quote(" ".join(split_command))[1:-1]
 
 
 class Context(DataProxy):

--- a/invoke/context.py
+++ b/invoke/context.py
@@ -25,17 +25,13 @@ if TYPE_CHECKING:
     from invoke.runners import Runner
 
 
-if sys.version_info >= (3, 8):
-
-    def shlex_join(split_command: List) -> str:
-        """Convert command from list to str."""
-        return shlex.join(split_command)
-
-else:
-
-    def shlex_join(split_command: List) -> str:
-        """Convert command from list to str."""
-        return shlex.quote(" ".join(split_command))[1:-1]
+def shlex_join(split_command: List) -> str:
+    """Convert command from list to str."""
+    return (
+        shlex.join(split_command)
+        if sys.version_info >= (3, 8)
+        else shlex.quote(" ".join(split_command))[1:-1]
+    )
 
 
 class Context(DataProxy):

--- a/invoke/context.py
+++ b/invoke/context.py
@@ -25,11 +25,14 @@ if TYPE_CHECKING:
     from invoke.runners import Runner
 
 
-if sys.version_info >= (3,8):
+if sys.version_info >= (3, 8):
+
     def shlex_join(split_command: List) -> str:
         """Convert command from list to str."""
         return shlex.join(split_command)
+
 else:
+
     def shlex_join(split_command: List) -> str:
         """Convert command from list to str."""
         return shlex.quote(" ".join(split_command))
@@ -99,7 +102,9 @@ class Context(DataProxy):
         # runtime.
         self._set(_config=value)
 
-    def run(self, command: Union[str, List[str]], **kwargs: Any) -> Optional[Result]:
+    def run(
+        self, command: Union[str, List[str]], **kwargs: Any
+    ) -> Optional[Result]:
         """
         Execute a local shell command, honoring config options.
 
@@ -126,7 +131,9 @@ class Context(DataProxy):
         command = self._prefix_commands(command)
         return runner.run(command, **kwargs)
 
-    def sudo(self, command: Union[str, List[str]], **kwargs: Any) -> Optional[Result]:
+    def sudo(
+        self, command: Union[str, List[str]], **kwargs: Any
+    ) -> Optional[Result]:
         """
         Execute a shell command via ``sudo`` with password auto-response.
 
@@ -564,7 +571,9 @@ class MockContext(Context):
             # raise_from(NotImplementedError(command), None)
             raise NotImplementedError(command)
 
-    def run(self, command: Union[str, List[str]], *args: Any, **kwargs: Any) -> Result:
+    def run(
+        self, command: Union[str, List[str]], *args: Any, **kwargs: Any
+    ) -> Result:
         # TODO: perform more convenience stuff associating args/kwargs with the
         # result? E.g. filling in .command, etc? Possibly useful for debugging
         # if one hits unexpected-order problems with what they passed in to
@@ -573,7 +582,9 @@ class MockContext(Context):
             command = shlex_join(command)
         return self._yield_result("__run", command)
 
-    def sudo(self, command: Union[str, List[str]] , *args: Any, **kwargs: Any) -> Result:
+    def sudo(
+        self, command: Union[str, List[str]], *args: Any, **kwargs: Any
+    ) -> Result:
         # TODO: this completely nukes the top-level behavior of sudo(), which
         # could be good or bad, depending. Most of the time I think it's good.
         # No need to supply dummy password config, etc.

--- a/invoke/context.py
+++ b/invoke/context.py
@@ -1,7 +1,5 @@
 import os
 import re
-import shlex
-import sys
 from contextlib import contextmanager
 from itertools import cycle
 from os import PathLike
@@ -19,23 +17,11 @@ from unittest.mock import Mock
 from .config import Config, DataProxy
 from .exceptions import Failure, AuthFailure, ResponseNotAccepted
 from .runners import Result
+from .shims import shlex_join
 from .watchers import FailingResponder
 
 if TYPE_CHECKING:
     from invoke.runners import Runner
-
-
-if sys.version_info >= (3, 8):
-
-    def shlex_join(split_command: List) -> str:
-        """Convert command from list to str."""
-        return shlex.join(split_command)
-
-else:
-
-    def shlex_join(split_command: List) -> str:
-        """Convert command from list to str."""
-        return shlex.quote(" ".join(split_command))[1:-1]
 
 
 class Context(DataProxy):

--- a/invoke/shims.py
+++ b/invoke/shims.py
@@ -1,0 +1,16 @@
+import shlex
+import sys
+from typing import List
+
+
+if sys.version_info >= (3, 8):
+
+    def shlex_join(split_command: List) -> str:
+        """Convert command from list to str."""
+        return shlex.join(split_command)
+
+else:
+
+    def shlex_join(split_command: List) -> str:
+        """Convert command from list to str."""
+        return shlex.quote(" ".join(split_command))[1:-1]

--- a/tests/context.py
+++ b/tests/context.py
@@ -76,7 +76,7 @@ class Context_:
                 c = Context()
                 c.sudo(["foo", "bar", "baz"])
                 cmd = "sudo -S -p '[sudo] password: ' foo bar baz"
-                assert runner.run.called, "run() never called runner.run()!"
+                assert runner.run.called, "sudo() never called runner.run()!"
                 assert runner.run.call_args[0][0] == cmd
 
     class configuration_proxy:

--- a/tests/context.py
+++ b/tests/context.py
@@ -754,17 +754,31 @@ class MockContext_:
                     with raises(TypeError):
                         mc.set_result_for("sudo", "whatever", Result("bar"))
 
-        def run(self):
-            mc = MockContext(run={"foo": Result("bar")})
-            assert mc.run("foo").stdout == "bar"
-            mc.set_result_for("run", "foo", Result("biz"))
-            assert mc.run("foo").stdout == "biz"
+        class run:
+            def sets_result_for_command_str(self):
+                mc = MockContext(run={"foo": Result("bar")})
+                assert mc.run("foo").stdout == "bar"
+                mc.set_result_for("run", "foo", Result("biz"))
+                assert mc.run("foo").stdout == "biz"
 
-        def sudo(self):
-            mc = MockContext(sudo={"foo": Result("bar")})
-            assert mc.sudo("foo").stdout == "bar"
-            mc.set_result_for("sudo", "foo", Result("biz"))
-            assert mc.sudo("foo").stdout == "biz"
+            def sets_result_for_command_list(self):
+                mc = MockContext(run={"foo fpp fqq": Result("bar")})
+                assert mc.run(["foo", "fpp", "fqq"]).stdout == "bar"
+                mc.set_result_for("run", "foo fpp fqq", Result("biz"))
+                assert mc.run(["foo", "fpp", "fqq"]).stdout == "biz"
+
+        class sudo:
+            def sets_result_for_command_str(self):
+                mc = MockContext(sudo={"foo": Result("bar")})
+                assert mc.sudo("foo").stdout == "bar"
+                mc.set_result_for("sudo", "foo", Result("biz"))
+                assert mc.sudo("foo").stdout == "biz"
+
+            def sets_result_for_command_list(self):
+                mc = MockContext(sudo={"foo fpp fqq": Result("bar")})
+                assert mc.sudo(["foo", "fpp", "fqq"]).stdout == "bar"
+                mc.set_result_for("sudo", "foo fpp fqq", Result("biz"))
+                assert mc.sudo(["foo", "fpp", "fqq"]).stdout == "biz"
 
     def wraps_run_and_sudo_with_Mock(self, clean_sys_modules):
         sys.modules["mock"] = None  # legacy

--- a/tests/context.py
+++ b/tests/context.py
@@ -57,8 +57,27 @@ class Context_:
                 c.run("foo")
                 assert runner_class.mock_calls == [call(c), call().run("foo")]
 
-        def sudo(self):
-            self._expect_attr("sudo")
+            @patch(local_path)
+            def converts_command_list_to_str(self, Local):
+                runner = Local.return_value
+                c = Context()
+                c.run(["foo", "bar", "baz"])
+                cmd = "foo bar baz"
+                assert runner.run.called, "run() never called runner.run()!"
+                assert runner.run.call_args[0][0] == cmd
+
+        class sudo:
+            def exists(self):
+                self._expect_attr("sudo")
+
+            @patch(local_path)
+            def converts_command_list_to_str(self, Local):
+                runner = Local.return_value
+                c = Context()
+                c.sudo(["foo", "bar", "baz"])
+                cmd = "sudo -S -p '[sudo] password: ' foo bar baz"
+                assert runner.run.called, "run() never called runner.run()!"
+                assert runner.run.call_args[0][0] == cmd
 
     class configuration_proxy:
         "Dict-like proxy for self.config"

--- a/tests/context.py
+++ b/tests/context.py
@@ -62,7 +62,7 @@ class Context_:
                 runner = Local.return_value
                 c = Context()
                 c.run(["foo", "bar", "baz"])
-                cmd = "foo bar baz"
+                cmd = "'foo bar baz'"
                 assert runner.run.called, "run() never called runner.run()!"
                 assert runner.run.call_args[0][0] == cmd
 
@@ -75,7 +75,7 @@ class Context_:
                 runner = Local.return_value
                 c = Context()
                 c.sudo(["foo", "bar", "baz"])
-                cmd = "sudo -S -p '[sudo] password: ' foo bar baz"
+                cmd = "sudo -S -p '[sudo] password: ' 'foo bar baz'"
                 assert runner.run.called, "sudo() never called runner.run()!"
                 assert runner.run.call_args[0][0] == cmd
 

--- a/tests/context.py
+++ b/tests/context.py
@@ -62,7 +62,7 @@ class Context_:
                 runner = Local.return_value
                 c = Context()
                 c.run(["foo", "bar", "baz"])
-                cmd = "'foo bar baz'"
+                cmd = "foo bar baz"
                 assert runner.run.called, "run() never called runner.run()!"
                 assert runner.run.call_args[0][0] == cmd
 
@@ -75,7 +75,7 @@ class Context_:
                 runner = Local.return_value
                 c = Context()
                 c.sudo(["foo", "bar", "baz"])
-                cmd = "sudo -S -p '[sudo] password: ' 'foo bar baz'"
+                cmd = "sudo -S -p '[sudo] password: ' foo bar baz"
                 assert runner.run.called, "sudo() never called runner.run()!"
                 assert runner.run.call_args[0][0] == cmd
 


### PR DESCRIPTION
## Description

1. Changed `Context.run()` and `Context.sudo()` to define `command` with the new type `Union[str, List[str]]` and handle the value with `shlex.join` if it is a list.

1. Updated `run()` and `sudo()` functions to use this new type.

1. Updated `Context_.methods_exposed.run` and `Context_.methods_exposed.sudo` classes to test this new type.

## Demo

Created tasks.py for demo:

```python
# pylint: disable-next=E0401:import-error
from invoke import task  # type: ignore

@task
def demo(ctx):
    import shlex  # pylint: disable=C0415:import-outside-toplevel

    ctx.config.run.echo = True
    command_list = ["git", "status", "--porcelain"]
    for command in [
        command_list,
        shlex.join(command_list),
    ]:
        try:
            print(f"** Demo: run {command=}")
            res = ctx.run(command)
        except TypeError as exc:
            print(f"** Error: {exc=}")
        else:
            print(f"** Success!: {res=}")
```

Results with invoke main

```pwsh
PS > pipx uninstall invoke
PS > pipx install 'git+https://github.com/pyinvoke/invoke@main'
  injected package invoke into venv invoke
done! ✨ 🌟 ✨
PS > invoke demo
** Demo: run command=['git', 'status', '--porcelain']
** Error: exc=TypeError('sequence item 0: expected str instance, list found')
** Demo: run command='git status --porcelain'
git status --porcelain
 M projects/bce-patch-builder/tasks.py
** Success!: res=<Result cmd='git status --porcelain' exited=0>
```

Results with invoke fork

```pwsh
PS > pipx uninstall invoke
PS > pipx install 'git+https://github.com/achekery/invoke@qol-commandlist'
  injected package invoke into venv invoke
done! ✨ 🌟 ✨
PS > invoke demo
** Demo: run command=['git', 'status', '--porcelain']
git status --porcelain
 M projects/bce-patch-builder/tasks.py
** Success!: res=<Result cmd='git status --porcelain' exited=0>
** Demo: run command='git status --porcelain'
git status --porcelain
 M projects/bce-patch-builder/tasks.py
** Success!: res=<Result cmd='git status --porcelain' exited=0>
```

