### PR TITLE
Add '!join' tag to config parser

### DIFF
--- a/invoke/vendor/yaml/constructor.py
+++ b/invoke/vendor/yaml/constructor.py
@@ -413,6 +413,10 @@ class SafeConstructor(BaseConstructor):
         value = self.construct_mapping(node)
         data.update(value)
 
+    def construct_yaml_join(self, node):
+        seq = self.construct_sequence(node)
+        return ''.join([str(i) for i in seq])
+
     def construct_yaml_object(self, node, cls):
         data = cls.__new__(cls)
         yield data
@@ -475,6 +479,10 @@ SafeConstructor.add_constructor(
 SafeConstructor.add_constructor(
         'tag:yaml.org,2002:map',
         SafeConstructor.construct_yaml_map)
+
+SafeConstructor.add_constructor(
+        '!join',
+        SafeConstructor.construct_yaml_join)
 
 SafeConstructor.add_constructor(None,
         SafeConstructor.construct_undefined)


### PR DESCRIPTION
When dealing with, e.g., paths in a configuration file, it is not uncommon to want to perform a `join` operation on two values in order to keep the config file 'DRY'. By adding a `!join` tag to the config parser, you can join one previously defined value in the `invoke.yaml` file with another. For example:
```yaml
base: &BASE /home/root/
app: !join [*BASE, my_app/]
settings: !join [*BASE, settings]
```