### PR TITLE
Properly annotate run functions

### DIFF
--- a/invoke/_types.py
+++ b/invoke/_types.py
@@ -1,0 +1,99 @@
+from typing import IO, TYPE_CHECKING, Union, overload, cast, Optional, Dict
+from typing_extensions import Protocol, TypedDict, Unpack, Literal
+
+
+if TYPE_CHECKING:
+    from invoke.runners import Promise, Result
+    from invoke.watchers import StreamWatcher
+
+
+def annotate_run_function(func: "_RunFunctionImpl") -> "RunFunction":
+    """Add standard run function annotations to a function."""
+    return cast(RunFunction, func)
+
+
+class _RunFunctionImpl(Protocol):
+
+    def __call__(
+        self, command: str, **kwargs: Unpack["RunParams"]
+    ) -> Optional[Result]: ...
+
+
+class _BaseRunParams(TypedDict, total=False):
+    dry: bool
+    echo: bool
+    echo_format: str
+    echo_stdin: Optional[bool]
+    encoding: Optional[str]
+    err_stream: IO
+    env: Dict[str, str]
+    fallback: bool
+    hide: Optional[bool]
+    in_stream: Optional[IO]
+    out_stream: IO
+    pty: bool
+    replace_env: bool
+    shell: str
+    timeout: Optional[int]
+    warn: bool
+    watchers: list[StreamWatcher]
+
+
+class RunParams(_BaseRunParams, total=False):
+    """Parameters for Runner.run"""
+
+    asynchronous: bool
+    disown: bool
+
+
+class RunFunction(Protocol):
+    """A function that runs a command."""
+
+    @overload
+    def __call__(
+        self,
+        command: str,
+        *,
+        disown: Literal[True],
+        **kwargs: Unpack[_BaseRunParams],
+    ) -> None: ...
+
+    @overload
+    def __call__(
+        self,
+        command: str,
+        *,
+        disown: bool,
+        **kwargs: Unpack[_BaseRunParams],
+    ) -> Optional[Result]: ...
+
+    @overload
+    def __call__(
+        self,
+        command: str,
+        *,
+        asynchronous: Literal[True],
+        **kwargs: Unpack[_BaseRunParams],
+    ) -> Promise: ...
+
+    @overload
+    def __call__(
+        self,
+        command: str,
+        *,
+        asynchronous: bool,
+        **kwargs: Unpack[_BaseRunParams],
+    ) -> Union[Promise, Result]: ...
+
+    @overload
+    def __call__(
+        self,
+        command: str,
+        **kwargs: Unpack[_BaseRunParams],
+    ) -> Result: ...
+
+    def __call__(
+        self,
+        command: str,
+        **kwargs: Unpack[RunParams],
+    ) -> Optional[Result]: ...

--- a/invoke/context.py
+++ b/invoke/context.py
@@ -14,6 +14,7 @@ from typing import (
 )
 from unittest.mock import Mock
 
+from ._types import annotate_run_function
 from .config import Config, DataProxy
 from .exceptions import Failure, AuthFailure, ResponseNotAccepted
 from .runners import Result
@@ -87,6 +88,7 @@ class Context(DataProxy):
         # runtime.
         self._set(_config=value)
 
+    @annotate_run_function
     def run(self, command: str, **kwargs: Any) -> Optional[Result]:
         """
         Execute a local shell command, honoring config options.
@@ -112,6 +114,7 @@ class Context(DataProxy):
         command = self._prefix_commands(command)
         return runner.run(command, **kwargs)
 
+    @annotate_run_function
     def sudo(self, command: str, **kwargs: Any) -> Optional[Result]:
         """
         Execute a shell command via ``sudo`` with password auto-response.

--- a/invoke/runners.py
+++ b/invoke/runners.py
@@ -36,6 +36,7 @@ try:
 except ImportError:
     termios = None  # type: ignore[assignment]
 
+from ._types import annotate_run_function
 from .exceptions import (
     UnexpectedExit,
     Failure,
@@ -122,6 +123,7 @@ class Runner:
         self._asynchronous = False
         self._disowned = False
 
+    @annotate_run_function
     def run(self, command: str, **kwargs: Any) -> Optional["Result"]:
         """
         Execute ``command``, returning an instance of `Result` once complete.


### PR DESCRIPTION
I'd like to run a type checker against the code in `tasks.py` however the fact that `Context.run` returns `Result | None` instead of just a `Result` makes it rather annoying to deal with. I constantly have to `assert result is not None` in order to access attributes like `Result.stdout`. Given the underlying implementation, the solution is to describe `run()` with overloads. Since there a number of public interfaces that look like `Context.run`, in this PR I've devised an `annotate_run_function` decorator that makes it easy to declare a function as having a `run`-like interface.

In order to make this happen I've had to use some newer typing features that are available for older versions of Python via [`typing_extensions`](https://pypi.org/project/typing-extensions/). I have noticed that `invoke` doesn't seem to have dependencies though so I'm not sure whether or not the maintainers would be alright adding it as a dependency or if I ought to figure out how to conditionally import from `typing_extensions`.