### PR TITLE
[WIP/suggestion]: Make no-idea errors less patronising

### DIFF
--- a/invoke/collection.py
+++ b/invoke/collection.py
@@ -120,7 +120,7 @@ class Collection:
         elif isinstance(obj, (Collection, ModuleType)):
             method = self.add_collection
         else:
-            raise TypeError("No idea how to insert {!r}!".format(type(obj)))
+            raise TypeError("Cannot insert {!r}.".format(type(obj)))
         method(obj, name=name)
 
     def __repr__(self) -> str:

--- a/invoke/parser/parser.py
+++ b/invoke/parser/parser.py
@@ -322,7 +322,7 @@ class ParseMachine(StateMachine):
         else:
             if not self.ignore_unknown:
                 debug("Can't find context named {!r}, erroring".format(token))
-                self.error("No idea what {!r} is!".format(token))
+                self.error("Flag {!r} not recognised".format(token))
             else:
                 debug("Bottom-of-handle() see_unknown({!r})".format(token))
                 self.see_unknown(token)

--- a/invoke/program.py
+++ b/invoke/program.py
@@ -511,7 +511,7 @@ class Program:
             else:
                 # TODO: feels real dumb to factor this out of Parser, but...we
                 # should?
-                raise ParseError("No idea what '{}' is!".format(halp))
+                raise ParseError("'{}' command not recognised.".format(halp))
 
         # Print discovered tasks if necessary
         list_root = self.args.list.value  # will be True or string

--- a/sites/docs/concepts/library.rst
+++ b/sites/docs/concepts/library.rst
@@ -140,7 +140,7 @@ The result?
       integration
 
     $ tester --list
-    No idea what '--list' is!
+    Command '--list' not recognised.
     $ tester unit
     Running unit tests!
 

--- a/tests/program.py
+++ b/tests/program.py
@@ -360,7 +360,7 @@ class Program_:
         def does_not_seek_tasks_module_if_namespace_was_given(self):
             expect(
                 "foo",
-                err="No idea what 'foo' is!\n",
+                err="Task 'foo' not recognised.",
                 program=Program(namespace=Collection("blank")),
             )
 
@@ -399,10 +399,10 @@ class Program_:
             nah = "nopenotvalidsorry"
             p.run("myapp {}".format(nah))
             # Expect that we did print the core body of the ParseError (e.g.
-            # "no idea what foo is!") and exit 1. (Intent is to display that
+            # "Command 'foo' not recognised.") and exit 1. (Intent is to display that
             # info w/o a full traceback, basically.)
             stderr = sys.stderr.getvalue()
-            assert stderr == "No idea what '{}' is!\n".format(nah)
+            assert stderr == "Command '{}' not recognised.\n".format(nah)
             mock_exit.assert_called_with(1)
 
         @trap
@@ -736,7 +736,7 @@ Options:
                 expect("-c decorators -h punch --list", out=expected)
 
             def complains_if_given_invalid_task_name(self):
-                expect("-h this", err="No idea what 'this' is!\n")
+                expect("-h this", err="Task 'this' not recognised.\n")
 
     class task_list:
         "--list"


### PR DESCRIPTION
I found myself rubbed up the wrong way one too many times by the current error message

```
No idea what 'thing' is!
```

It just came across -- to me -- as patronising rather than cute.  Hoping we can find a kinder or more empathetic message.  Some suggestions in the diff!