### PR TITLE
Add Python 3.12 and 3.13 to test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ workflows:
           requires: ["Test"]
           matrix:
             parameters:
-              version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+              version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
       - orb/docs:
           name: "Docs"
           requires: ["Test"]


### PR DESCRIPTION
Note that Python 3.7 and 3.8 are EOL, so should probably be removed from the matrix