### PR TITLE
Fix #1011 nixos doesnt have /bin/bash

### DIFF
--- a/invoke/config.py
+++ b/invoke/config.py
@@ -449,7 +449,7 @@ class Config(DataProxy):
         # TODO: consider an automatic fallback to /bin/sh for systems lacking
         # /bin/bash; however users may configure run.shell quite easily, so...
         else:
-            shell = "/bin/bash"
+            shell = "bash"
 
         return {
             # TODO: we document 'debug' but it's not truly implemented outside

--- a/invoke/runners.py
+++ b/invoke/runners.py
@@ -1327,12 +1327,11 @@ class Local(Runner):
                 # TODO: make subroutine?
                 winsize = struct.pack("HHHH", rows, cols, 0, 0)
                 fcntl.ioctl(sys.stdout.fileno(), termios.TIOCSWINSZ, winsize)
-                # Use execve for bare-minimum "exec w/ variable # args + env"
-                # behavior. No need for the 'p' (use PATH to find executable)
-                # for now.
+                # Use execvpe for bare-minimum "exec w/ variable # args + env"
+                # behavior.
                 # NOTE: stdlib subprocess (actually its posix flavor, which is
                 # written in C) uses either execve or execv, depending.
-                os.execve(shell, [shell, "-c", command], env)
+                os.execvpe(shell, [shell, "-c", command], env)
         else:
             self.process = Popen(
                 command,

--- a/sites/www/changelog.rst
+++ b/sites/www/changelog.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+- :bug:`1011`: On some systems, the default configuration for the shell
+  to use provoked a crash, due to the shell binary being in a different
+  path. A fix has been introduced to switch to execution with `$PATH`
+  binary search (execvpe). Previous custom shell configurations are unaffected.
+  Thanks to Lou Lecrivain for the patch.
 - :release:`2.2.0 <2023-07-12>`
 - :feature:`-` Remove the somewhat inaccurate subclass requirement around
   `~invoke.config.Config`'s ``.clone(into=...)`` constructor call. It was

--- a/tests/_util.py
+++ b/tests/_util.py
@@ -250,7 +250,7 @@ def mock_pty(
             assert ioctl.call_args_list[0][0][1] == termios.TIOCGWINSZ
             assert ioctl.call_args_list[1][0][1] == termios.TIOCSWINSZ
             if not skip_asserts:
-                for name in ("execve", "waitpid"):
+                for name in ("execvpe", "waitpid"):
                     assert getattr(os, name).called
                 # Ensure at least one of the exit status getters was called
                 assert os.WEXITSTATUS.called or os.WTERMSIG.called

--- a/tests/config.py
+++ b/tests/config.py
@@ -107,7 +107,7 @@ class Config_:
                     "out_stream": None,
                     "pty": False,
                     "replace_env": False,
-                    "shell": "/bin/bash",
+                    "shell": "bash",
                     "warn": False,
                     "watchers": [],
                 },

--- a/tests/runners.py
+++ b/tests/runners.py
@@ -81,7 +81,7 @@ def _expect_platform_shell(shell):
     if WINDOWS:
         assert shell.endswith("cmd.exe")
     else:
-        assert shell == "/bin/bash"
+        assert shell == "bash"
 
 
 def _make_tcattrs(cc_is_ints=True, echo=False):
@@ -1655,7 +1655,7 @@ class Local_:
             # NOTE: yea, windows can't run pty is true, but this is really
             # testing config behavior, so...meh
             self._run(_, pty=True)
-            _expect_platform_shell(mock_os.execve.call_args_list[0][0][0])
+            _expect_platform_shell(mock_os.execvpe.call_args_list[0][0][0])
 
         @mock_subprocess(insert_Popen=True)
         def defaults_to_bash_or_cmdexe_when_pty_False(self, mock_Popen):
@@ -1667,7 +1667,7 @@ class Local_:
         @mock_pty(insert_os=True)
         def may_be_overridden_when_pty_True(self, mock_os):
             self._run(_, pty=True, shell="/bin/zsh")
-            assert mock_os.execve.call_args_list[0][0][0] == "/bin/zsh"
+            assert mock_os.execvpe.call_args_list[0][0][0] == "/bin/zsh"
 
         @mock_subprocess(insert_Popen=True)
         def may_be_overridden_when_pty_False(self, mock_Popen):
@@ -1690,7 +1690,7 @@ class Local_:
             type(mock_os).environ = {"OTHERVAR": "OTHERVAL"}
             self._run(_, pty=True, env={"FOO": "BAR"})
             expected = {"OTHERVAR": "OTHERVAL", "FOO": "BAR"}
-            env = mock_os.execve.call_args_list[0][0][2]
+            env = mock_os.execvpe.call_args_list[0][0][2]
             assert env == expected
 
     class close_proc_stdin:


### PR DESCRIPTION
Hello,

As previously discussed, please find attached the PR to fix #1011.
Summary of changes:
- switched from `execve` to `execvpe`
- minimal changes to test suite to accomodate switch to `execvpe`
- added changelog fragment

I ran the regression test and the test suite, everything's green.

I did not add a fallback option, to be honest I don't think systems with bash installed in `/bin`, `/usr/bin` or elsewhere but without these directories being in the `PATH` are really a concern. If we really need this, I can take care to add it.

This should not break any user's configuration files, as `execvpe` also accepts absolute paths for executables.