### PR TITLE
handle `SystemError` exception

### DIFF
--- a/invoke/terminals.py
+++ b/invoke/terminals.py
@@ -107,7 +107,7 @@ else:
         # * termios not having a TIOCGWINSZ attribute (happens sometimes...)
         # * other situations where ioctl doesn't explode but the result isn't
         #   something unpack can deal with
-        except (struct.error, TypeError, IOError, AttributeError):
+        except (struct.error, TypeError, IOError, AttributeError, SystemError):
             pass
         return size
 


### PR DESCRIPTION
Fixes the following test failures when building with Python3.14:
```
=========================== short test summary info ============================
FAILED tests/runners.py::Local_::pty::when_pty_True_we_use_pty_fork_and_os_exec - SystemError: buffer overflow
FAILED tests/runners.py::Local_::pty::pty_uses_WEXITSTATUS_if_WIFEXITED - SystemError: buffer overflow
FAILED tests/runners.py::Local_::pty::pty_uses_WTERMSIG_if_WIFSIGNALED - SystemError: buffer overflow
FAILED tests/runners.py::Local_::pty::WTERMSIG_result_turned_negative_to_match_subprocess - SystemError: buffer overflow
FAILED tests/runners.py::Local_::pty::pty_is_set_to_controlling_terminal_size - SystemError: buffer overflow
FAILED tests/runners.py::Local_::pty::spurious_OSErrors_handled_gracefully - SystemError: buffer overflow
FAILED tests/runners.py::Local_::pty::other_spurious_OSErrors_handled_gracefully - SystemError: buffer overflow
FAILED tests/runners.py::Local_::pty::non_spurious_OSErrors_bubble_up - SystemError: buffer overflow
FAILED tests/runners.py::Local_::pty::stop_mutes_errors_on_pty_close - SystemError: buffer overflow
FAILED tests/runners.py::Local_::pty::fallback::can_be_overridden_by_kwarg - SystemError: buffer overflow
FAILED tests/runners.py::Local_::pty::fallback::can_be_overridden_by_config - SystemError: buffer overflow
FAILED tests/runners.py::Local_::pty::fallback::overridden_fallback_affects_result_pty_value - SystemError: buffer overflow
FAILED tests/runners.py::Local_::shell::defaults_to_bash_or_cmdexe_when_pty_True - SystemError: buffer overflow
FAILED tests/runners.py::Local_::shell::may_be_overridden_when_pty_True - SystemError: buffer overflow
FAILED tests/runners.py::Local_::env::uses_execve_for_pty_True - SystemError: buffer overflow
FAILED tests/terminals.py::terminals::pty_size::calls_fcntl_with_TIOCGWINSZ - SystemError: buffer overflow
================== 16 failed, 952 passed, 11 skipped in 6.67s ==================
```

Resolves #1038 .