### PR TITLE
fix: Buffer overflow in bytes_to_read

### DIFF
--- a/invoke/terminals.py
+++ b/invoke/terminals.py
@@ -243,6 +243,7 @@ def bytes_to_read(input_: IO) -> int:
     # it's not a tty but has a fileno, or vice versa; neither is typically
     # going to work re: ioctl().
     if not WINDOWS and isatty(input_) and has_fileno(input_):
-        fionread = fcntl.ioctl(input_, termios.FIONREAD, b"  ")
-        return int(struct.unpack("h", fionread)[0])
+        arg = bytes(bytearray(struct.calcsize("i")))
+        fionread = fcntl.ioctl(input_, termios.FIONREAD, arg)
+        return int(struct.unpack("i", fionread)[0])
     return 1

--- a/tests/runners.py
+++ b/tests/runners.py
@@ -1224,7 +1224,7 @@ stderr 25
                 # This works since each mocked attr will still be its own mock
                 # object with a distinct 'is' identity.
                 if cmd is termios.FIONREAD:
-                    return struct.pack("h", len(stdin_data))
+                    return struct.pack("i", len(stdin_data))
 
             ioctl.side_effect = fake_ioctl
             # Set up our runner as one w/ mocked stdin writing (simplest way to


### PR DESCRIPTION
Hi there :wave: 

I encountered a runtime exception in `invoke/terminals.py::bytes_to_read` on Python 3.14.

I believe the issue is because the original version passed the incorrect sized `arg` to `fcntl.ioctl`.


>  [gh-132915](https://github.com/python/cpython/issues/132915): [fcntl.fcntl()](https://docs.python.org/3/library/
>  fcntl.html#fcntl.fcntl) and [fcntl.ioctl()](https://docs.python.org/3/library/fcntl.html#fcntl.ioctl) can now detect a buffer overflow and raise [SystemError](https://docs.python.org/3/library/exceptions.html#SystemError). The stack and memory can be corrupted in such case, so treat this error as fatal.

See [https://github.com/python/cpython/issues/132915](https://github.com/python/cpython/issues/132915)

I have created this PR which provides correctly sized `arg`.
