### PR TITLE
fix: raise ConfigFileNotFound when explicit runtime config path is missing (#560)

### DIFF
--- a/invoke/__init__.py
+++ b/invoke/__init__.py
@@ -8,6 +8,7 @@ from .exceptions import (  # noqa
     AmbiguousEnvVar,
     AuthFailure,
     CollectionNotFound,
+    ConfigFileNotFound,
     CommandTimedOut,
     Exit,
     ParseError,

--- a/invoke/config.py
+++ b/invoke/config.py
@@ -9,7 +9,9 @@ from types import ModuleType
 from typing import Any, Dict, Iterator, Optional, Tuple, Type, Union
 
 from .env import Environment
-from .exceptions import ConfigFileNotFound, UnknownFileType, UnpicklableConfigMember
+from .exceptions import (
+    ConfigFileNotFound, UnknownFileType, UnpicklableConfigMember
+)
 from .runners import Local
 from .terminals import WINDOWS
 from .util import debug, yaml
@@ -900,7 +902,8 @@ class Config(DataProxy):
             except IOError as e:
                 if e.errno == 2:
                     # Absolute paths (runtime config) were explicitly given by
-                    # the user; a missing file is an error, not "not configured".
+                    # the user; a missing file is an error,
+                    # not "not configured".
                     if absolute:
                         raise ConfigFileNotFound(str(filepath)) from e
                     err = "Didn't see any {}, skipping."

--- a/invoke/config.py
+++ b/invoke/config.py
@@ -9,7 +9,7 @@ from types import ModuleType
 from typing import Any, Dict, Iterator, Optional, Tuple, Type, Union
 
 from .env import Environment
-from .exceptions import UnknownFileType, UnpicklableConfigMember
+from .exceptions import ConfigFileNotFound, UnknownFileType, UnpicklableConfigMember
 from .runners import Local
 from .terminals import WINDOWS
 from .util import debug, yaml

--- a/invoke/config.py
+++ b/invoke/config.py
@@ -899,6 +899,10 @@ class Config(DataProxy):
             # Typically means 'no such file', so just note & skip past.
             except IOError as e:
                 if e.errno == 2:
+                    # Absolute paths (runtime config) were explicitly given by
+                    # the user; a missing file is an error, not "not configured".
+                    if absolute:
+                        raise ConfigFileNotFound(str(filepath)) from e
                     err = "Didn't see any {}, skipping."
                     debug(err.format(filepath))
                 else:

--- a/invoke/config.py
+++ b/invoke/config.py
@@ -10,7 +10,9 @@ from typing import Any, Dict, Iterator, Optional, Tuple, Type, Union
 
 from .env import Environment
 from .exceptions import (
-    ConfigFileNotFound, UnknownFileType, UnpicklableConfigMember
+    ConfigFileNotFound,
+    UnknownFileType,
+    UnpicklableConfigMember,
 )
 from .runners import Local
 from .terminals import WINDOWS

--- a/invoke/exceptions.py
+++ b/invoke/exceptions.py
@@ -302,7 +302,8 @@ class ConfigFileNotFound(IOError):
     def __init__(self, path: str) -> None:
         self.path = path
         super().__init__(
-            "Runtime config file {!r} was not found. Check the path for typos.".format(path)
+            ("Runtime config file {!r} was not found."
+             " Check the path for typos.").format(path)
         )
 
 

--- a/invoke/exceptions.py
+++ b/invoke/exceptions.py
@@ -286,6 +286,26 @@ class UnknownFileType(Exception):
     pass
 
 
+class ConfigFileNotFound(IOError):
+    """
+    A runtime config file was explicitly specified but could not be found.
+
+    Raised by `Config._load_file` when the user supplies an explicit path
+    (via ``--config`` on the CLI or ``runtime_path=`` kwarg) and that file
+    does not exist. Unlike the implicit search for system/user/project config
+    files — where a missing file simply means "not configured" — a missing
+    *explicit* runtime config is always a user error.
+
+    .. versionadded:: 2.3
+    """
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+        super().__init__(
+            "Runtime config file {!r} was not found. Check the path for typos.".format(path)
+        )
+
+
 class UnpicklableConfigMember(Exception):
     """
     A config file contained module objects, which can't be pickled/copied.

--- a/invoke/exceptions.py
+++ b/invoke/exceptions.py
@@ -302,8 +302,9 @@ class ConfigFileNotFound(IOError):
     def __init__(self, path: str) -> None:
         self.path = path
         super().__init__(
-            ("Runtime config file {!r} was not found."
-             " Check the path for typos.").format(path)
+            "Runtime config file {!r} was not found. Check the path for typos.".format(
+                path
+            )
         )
 
 

--- a/invoke/exceptions.py
+++ b/invoke/exceptions.py
@@ -301,11 +301,11 @@ class ConfigFileNotFound(IOError):
 
     def __init__(self, path: str) -> None:
         self.path = path
-        super().__init__(
-            "Runtime config file {!r} was not found. Check the path for typos.".format(
-                path
-            )
+        msg = (
+            "Runtime config file {!r} was not found."
+            " Check the path for typos."
         )
+        super().__init__(msg.format(path))
 
 
 class UnpicklableConfigMember(Exception):

--- a/tests/_support/configs/dedupe.yaml
+++ b/tests/_support/configs/dedupe.yaml
@@ -1,0 +1,2 @@
+tasks:
+  dedupe: true

--- a/tests/config.py
+++ b/tests/config.py
@@ -658,13 +658,14 @@ Valid real attributes: ['clear', 'clone', 'env_prefix', 'file_prefix', 'from_dat
             with pytest.raises(UnpicklableConfigMember, match=expected):
                 c.load_runtime(merge=False)
 
-        @patch("invoke.config.debug")
-        def nonexistent_files_are_skipped_and_logged(self, mock_debug):
+        @raises(ConfigFileNotFound)
+        def missing_explicit_runtime_path_raises(self):
+            # Regression for #560: explicit runtime paths that don't exist must
+            # raise ConfigFileNotFound, not silently continue.
             c = Config()
             c._load_yml = Mock(side_effect=IOError(2, "aw nuts"))
             c.set_runtime_path("is-a.yml")  # Triggers use of _load_yml
             c.load_runtime()
-            mock_debug.assert_any_call("Didn't see any is-a.yml, skipping.")
 
         @raises(IOError)
         def non_missing_file_IOErrors_are_raised(self):

--- a/tests/config.py
+++ b/tests/config.py
@@ -12,6 +12,7 @@ from invoke.config import Config
 from invoke.exceptions import (
     AmbiguousEnvVar,
     UncastableEnvVar,
+    ConfigFileNotFound,
     UnknownFileType,
     UnpicklableConfigMember,
 )
@@ -618,6 +619,22 @@ Valid real attributes: ['clear', 'clone', 'env_prefix', 'file_prefix', 'from_dat
         def unknown_suffix_in_runtime_path_raises_useful_error(self):
             c = Config(runtime_path=join(CONFIGS_PATH, "screw.ini"))
             c.load_runtime()
+
+        @raises(ConfigFileNotFound)
+        def missing_runtime_path_raises_config_file_not_found(self):
+            # Regression for #560: when the user provides an explicit runtime
+            # config path that doesn't exist, invoke should raise immediately
+            # instead of silently continuing with no config loaded.
+            c = Config(runtime_path=join(CONFIGS_PATH, "nonexistent_typo.yaml"))
+            c.load_runtime()
+
+        def missing_runtime_path_error_includes_path(self):
+            # ConfigFileNotFound.path must match what was supplied.
+            bad = join(CONFIGS_PATH, "nonexistent_typo.yaml")
+            c = Config(runtime_path=bad)
+            with pytest.raises(ConfigFileNotFound) as exc_info:
+                c.load_runtime()
+            assert exc_info.value.path == bad
 
         def python_modules_dont_load_special_vars(self):
             "Python modules don't load special vars"

--- a/tests/config.py
+++ b/tests/config.py
@@ -625,7 +625,9 @@ Valid real attributes: ['clear', 'clone', 'env_prefix', 'file_prefix', 'from_dat
             # Regression for #560: when the user provides an explicit runtime
             # config path that doesn't exist, invoke should raise immediately
             # instead of silently continuing with no config loaded.
-            c = Config(runtime_path=join(CONFIGS_PATH, "nonexistent_typo.yaml"))
+            c = Config(
+                runtime_path=join(CONFIGS_PATH, "nonexistent_typo.yaml")
+            )
             c.load_runtime()
 
         def missing_runtime_path_error_includes_path(self):


### PR DESCRIPTION
## Summary

Fixes #560 — when the user provides an explicit runtime config path (via `--config /path/to/file.yaml` or `runtime_path=` kwarg) and that file does not exist, invoke silently continues with no config loaded and no error.

## Root cause

`Config._load_file()` catches `IOError` with `errno == 2` (file not found) and logs a debug message, then continues. This is correct for the *implicit* config search (invoke tries `.invoke.yaml`, `.invoke.yml`, etc. in order and silently skips each missing option). But for the **explicit runtime config path** (`absolute=True`), the user chose a specific file; a missing file is a user error, not "not configured".

## Fix

Three changes:

**`invoke/exceptions.py`** — new `ConfigFileNotFound(IOError)` exception class with a `.path` attribute.

**`invoke/config.py`** — in the `errno == 2` handler, `raise ConfigFileNotFound` when `absolute=True`. Non-runtime sources keep their silent-skip behaviour.

**`tests/config.py`** — two regression tests:
- `missing_runtime_path_raises_config_file_not_found`
- `missing_runtime_path_error_includes_path`

## Before / after

```
# Before: runs normally, typo in path goes undetected
$ inv --config /tmp/doesnt_exist.yaml sometask

# After:
$ inv --config /tmp/doesnt_exist.yaml sometask
invoke.exceptions.ConfigFileNotFound: Runtime config file '/tmp/doesnt_exist.yaml' was not found. Check the path for typos.
```

`ConfigFileNotFound` extends `IOError` so existing `except IOError` handlers in user code continue to work.

## Checklist

- [x] New exception class in `exceptions.py` with `.path` attribute
- [x] `config.py` raises `ConfigFileNotFound` only when `absolute=True`
- [x] Implicit config search (system/user/project) unaffected
- [x] Regression tests added
- [x] `ConfigFileNotFound` importable from `invoke.exceptions`
